### PR TITLE
feat: add DuplicateValuesValidator to check for duplicate values in translation files

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,22 +46,23 @@ composer validate-translations [<path>] [-dr|--dry-run] [-f|--format cli|json] [
 
 ### Supported Formats
 
-The plugin supports the following translation file formats:
+The plugin supports the following translation file formats (and targets the following frameworks):
 
-| Format | File endings       | Description                                                                                                    | Example files                          |
-|--------|--------------------|----------------------------------------------------------------------------------------------------------------|----------------------------------------|
-| XLIFF  | `*.xlf`, `*.xliff` | Supports source/target translations in xliff language files. Used e.g. within [TYPO3 CMS](https://typo3.org/). | `locallang.xlf`, `de.locallang.xlf`    |
-| Yaml   | `*.yml`, `*.yaml`  | Supports yaml language files. Used e.g. within [Symfony Framework](https://symfony.com/).                      | `messages.en.yaml`, `messages.de.yaml` |
+| Format | Description                                                                                                  | Framework | Example files                          |
+|--------|--------------------------------------------------------------------------------------------------------------|-----------|----------------------------------------|
+| XLIFF  | Supports source/target translations in xliff language files. | [TYPO3 CMS](https://typo3.org/)          | `locallang.xlf`, `de.locallang.xlf`    |
+| Yaml   | Supports yaml language files.                     | [Symfony Framework](https://symfony.com/)          | `messages.en.yaml`, `messages.de.yaml` |
 
 ### Validators
 
 The following validators are available:
 
-| Validator                | Function                                                                                                                                                                 | Supports    |
-|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-| `MismatchValidator`      | This validator checks for keys that are present in some files but not in others. It helps to identify mismatches in translation keys across different translation files. | XLIFF, Yaml |
-| `DuplicateKeysValidator` | This validator checks for duplicate keys in translation files.                                                                                                           | XLIFF       |
-| `SchemaValidator`        | Validates the XML schema of translation files against the XLIFF standard. See available [schemas](https://github.com/symfony/translation/tree/6.4/Resources/schemas).    | XLIFF       |
+| Validator                  | Function                                                                                                                                                                 | Supports    | Throws  |
+|----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|---------|
+| `MismatchValidator`        | This validator checks for keys that are present in some files but not in others. It helps to identify mismatches in translation keys across different translation files. | XLIFF, Yaml | ERROR   |
+| `DuplicateKeysValidator`   | This validator checks for duplicate keys in translation files.                                                                                                           | XLIFF       | ERROR   |
+| `DuplicateValuesValidator` | This validator checks for duplicate values in translation files.                                                                                                         | XLIFF, Yaml     | WARNING |
+| `SchemaValidator`          | Validates the XML schema of translation files against the XLIFF standard. See available [schemas](https://github.com/symfony/translation/tree/6.4/Resources/schemas).    | XLIFF       | ERROR   |
 
 
 ## 🧑‍💻 Contributing

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         displayDetailsOnTestsThatTriggerWarnings="true"
          bootstrap="vendor/autoload.php"
          colors="true"
 >

--- a/src/Result/CliRenderer.php
+++ b/src/Result/CliRenderer.php
@@ -36,7 +36,7 @@ class CliRenderer implements RendererInterface
         $this->renderIssues();
         if ($this->resultType->notFullySuccessful()) {
             $this->io->newLine();
-            $this->io->{$this->dryRun ? 'warning' : 'error'}(
+            $this->io->{$this->dryRun || ResultType::WARNING === $this->resultType ? 'warning' : 'error'}(
                 $this->dryRun
                     ? 'Language validation failed and completed in dry-run mode.'
                     : 'Language validation failed.'

--- a/src/Validator/DuplicateValuesValidator.php
+++ b/src/Validator/DuplicateValuesValidator.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoveElevator\ComposerTranslationValidator\Validator;
+
+use MoveElevator\ComposerTranslationValidator\Parser\ParserInterface;
+use MoveElevator\ComposerTranslationValidator\Parser\XliffParser;
+use MoveElevator\ComposerTranslationValidator\Parser\YamlParser;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Helper\TableSeparator;
+use Symfony\Component\Console\Helper\TableStyle;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class DuplicateValuesValidator extends AbstractValidator implements ValidatorInterface
+{
+    /** @var array<string, array<string, array<int, string>>> */
+    protected array $valuesArray = [];
+
+    /**
+     * @return array<string, int>
+     */
+    public function processFile(ParserInterface $file): array
+    {
+        $keys = $file->extractKeys();
+
+        if (!$keys) {
+            $this->logger?->error('The source file '.$file->getFileName().' is not valid.');
+
+            return [];
+        }
+
+        foreach ($keys as $key) {
+            $value = $file->getContentByKey($key);
+            $this->valuesArray[$file->getFileName()][$value][] = $key;
+        }
+
+        return [];
+    }
+
+    public function postProcess(): void
+    {
+        foreach ($this->valuesArray as $file => $valueKeyArray) {
+            $duplicates = [];
+            foreach ($valueKeyArray as $value => $keys) {
+                if (count(array_unique($keys)) > 1) {
+                    $duplicates[$value] = array_unique($keys);
+                }
+            }
+            if (!empty($duplicates)) {
+                $this->issues[] = [
+                    'file' => $file,
+                    'issues' => $duplicates,
+                ];
+            }
+        }
+    }
+
+    /**
+     * @param array<string, array<int, array{
+     *      file: string,
+     *      issues: array<string, array<int, string>>,
+     *  }>> $issueSets
+     */
+    public function renderIssueSets(InputInterface $input, OutputInterface $output, array $issueSets): void
+    {
+        $rows = [];
+        $currentFile = null;
+
+        foreach ($issueSets as $duplicate) {
+            if ($currentFile !== $duplicate['file'] && null !== $currentFile) {
+                $rows[] = new TableSeparator();
+            }
+            $currentFile = $duplicate['file'];
+            foreach ($duplicate['issues'] as $value => $keys) {
+                $rows[] = [
+                    '<fg=red>'.$duplicate['file'].'</>',
+                    implode("\n", $keys),
+                    '<fg=yellow>'.$value.'</>',
+                ];
+                $duplicate['file'] = '';
+            }
+        }
+
+        (new Table($output))
+            ->setHeaders(['File', 'Key', 'Value'])
+            ->setRows($rows)
+            ->setStyle(
+                (new TableStyle())
+                    ->setCellHeaderFormat('%s')
+            )
+            ->render();
+    }
+
+    public function explain(): string
+    {
+        return 'This validator checks for duplicate values in translation files. '
+            .'If a value is assigned to multiple keys in a file, it will be reported as an issue.';
+    }
+
+    /**
+     * @return class-string<ParserInterface>[]
+     */
+    public function supportsParser(): array
+    {
+        return [XliffParser::class, YamlParser::class];
+    }
+
+    public function resultTypeOnValidationFailure(): ResultType
+    {
+        return ResultType::WARNING;
+    }
+}

--- a/src/Validator/DuplicateValuesValidator.php
+++ b/src/Validator/DuplicateValuesValidator.php
@@ -33,6 +33,9 @@ class DuplicateValuesValidator extends AbstractValidator implements ValidatorInt
 
         foreach ($keys as $key) {
             $value = $file->getContentByKey($key);
+            if (null === $value) {
+                continue;
+            }
             $this->valuesArray[$file->getFileName()][$value][] = $key;
         }
 
@@ -58,28 +61,28 @@ class DuplicateValuesValidator extends AbstractValidator implements ValidatorInt
     }
 
     /**
-     * @param array<string, array<int, array{
-     *      file: string,
-     *      issues: array<string, array<int, string>>,
-     *  }>> $issueSets
+     * @param array<string, array<int, array{file: string, issues: array<string, array<int, string>>}>> $issueSets
      */
     public function renderIssueSets(InputInterface $input, OutputInterface $output, array $issueSets): void
     {
         $rows = [];
         $currentFile = null;
 
-        foreach ($issueSets as $duplicate) {
-            if ($currentFile !== $duplicate['file'] && null !== $currentFile) {
-                $rows[] = new TableSeparator();
-            }
-            $currentFile = $duplicate['file'];
-            foreach ($duplicate['issues'] as $value => $keys) {
-                $rows[] = [
-                    '<fg=red>'.$duplicate['file'].'</>',
-                    implode("\n", $keys),
-                    '<fg=yellow>'.$value.'</>',
-                ];
-                $duplicate['file'] = '';
+        foreach ($issueSets as $issueSet) {
+            foreach ($issueSet as $duplicate) {
+                if ($currentFile !== $duplicate['file'] && null !== $currentFile) {
+                    $rows[] = new TableSeparator();
+                }
+                $currentFile = $duplicate['file'];
+                $fileName = $duplicate['file'];
+                foreach ($duplicate['issues'] as $value => $keys) {
+                    $rows[] = [
+                        '<fg=red>'.$fileName.'</>',
+                        implode("\n", $keys),
+                        '<fg=yellow>'.$value.'</>',
+                    ];
+                    $fileName = '';
+                }
             }
         }
 

--- a/src/Validator/ValidatorRegistry.php
+++ b/src/Validator/ValidatorRegistry.php
@@ -14,6 +14,7 @@ class ValidatorRegistry
         return [
             MismatchValidator::class,
             DuplicateKeysValidator::class,
+            DuplicateValuesValidator::class,
             SchemaValidator::class,
         ];
     }

--- a/tests/composer.json
+++ b/tests/composer.json
@@ -29,7 +29,7 @@
 		"translation:yaml:fail:check": "@composer validate-translations ./src/Fixtures/translations/yaml/fail --dry-run",
 		"translation:yaml:success": "@composer validate-translations ./src/Fixtures/translations/yaml/success",
 		"translation:yaml:success:check": "@composer validate-translations ./src/Fixtures/translations/yaml/success --dry-run",
-		"translation:xliff:duplicates": "@composer validate-translations ./src/Fixtures/translations/xliff/fail ./src/Fixtures/translations/xliff/success --validator=\"MoveElevator\\\\ComposerTranslationValidator\\\\Validator\\\\DuplicatesValidator\"",
+		"translation:xliff:duplicates": "@composer validate-translations ./src/Fixtures/translations/xliff/fail ./src/Fixtures/translations/xliff/success --validator=\"MoveElevator\\\\ComposerTranslationValidator\\\\Validator\\\\DuplicateValuesValidator\"",
 		"translation:xliff:fail:json": "@composer validate-translations ./src/Fixtures/translations/xliff/fail --format=json"
 	}
 }

--- a/tests/src/Fixtures/translations/xliff/fail/de.locallang.xlf
+++ b/tests/src/Fixtures/translations/xliff/fail/de.locallang.xlf
@@ -11,6 +11,14 @@
                 <source/>
                 <target>German Key #3</target>
             </trans-unit>
+            <trans-unit id="key4">
+                <source/>
+                <target>German Key #3</target>
+            </trans-unit>
+            <trans-unit id="key5">
+                <source/>
+                <target>German Key #1</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/tests/src/Fixtures/translations/xliff/fail/locallang.xlf
+++ b/tests/src/Fixtures/translations/xliff/fail/locallang.xlf
@@ -9,6 +9,9 @@
             <trans-unit id="key1">
                 <source>English Key #1</source>
             </trans-unit>
+            <trans-unit id="key3">
+                <source>English Key #1</source>
+            </trans-unit>
             <trans-unit id="key2">
                 <source>English Key #2</source>
             </trans-unit>

--- a/tests/src/Validator/DuplicateValuesValidatorTest.php
+++ b/tests/src/Validator/DuplicateValuesValidatorTest.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoveElevator\ComposerTranslationValidator\Tests\Validator;
+
+use MoveElevator\ComposerTranslationValidator\Parser\ParserInterface;
+use MoveElevator\ComposerTranslationValidator\Parser\XliffParser;
+use MoveElevator\ComposerTranslationValidator\Parser\YamlParser;
+use MoveElevator\ComposerTranslationValidator\Validator\DuplicateValuesValidator;
+use MoveElevator\ComposerTranslationValidator\Validator\ResultType;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+final class DuplicateValuesValidatorTest extends TestCase
+{
+    private MockObject|LoggerInterface $loggerMock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->loggerMock = $this->createMock(LoggerInterface::class);
+    }
+
+    public function testProcessFileWithDuplicateValues(): void
+    {
+        $parser = $this->createMock(ParserInterface::class);
+        $parser->method('extractKeys')->willReturn(['key1', 'key2', 'key3']);
+        $parser->method('getContentByKey')
+            ->willReturnMap([
+                ['key1', 'source', 'valueA'],
+                ['key2', 'source', 'valueB'],
+                ['key3', 'source', 'valueA'], // Duplicate value
+            ]);
+        $parser->method('getFileName')->willReturn('test.xlf');
+
+        $validator = new DuplicateValuesValidator($this->loggerMock);
+        $validator->processFile($parser);
+
+        // Access protected property to check internal state
+        $reflection = new \ReflectionClass($validator);
+        $valuesArrayProperty = $reflection->getProperty('valuesArray');
+        $valuesArrayProperty->setAccessible(true);
+        $valuesArray = $valuesArrayProperty->getValue($validator);
+
+        $this->assertArrayHasKey('test.xlf', $valuesArray);
+        $this->assertArrayHasKey('valueA', $valuesArray['test.xlf']);
+        $this->assertSame(['key1', 'key3'], $valuesArray['test.xlf']['valueA']);
+    }
+
+    public function testProcessFileWithoutDuplicateValues(): void
+    {
+        $parser = $this->createMock(ParserInterface::class);
+        $parser->method('extractKeys')->willReturn(['key1', 'key2', 'key3']);
+        $parser->method('getContentByKey')
+            ->willReturnMap([
+                ['key1', 'source', 'valueA'],
+                ['key2', 'source', 'valueB'],
+                ['key3', 'source', 'valueC'],
+            ]);
+        $parser->method('getFileName')->willReturn('test.xlf');
+
+        $validator = new DuplicateValuesValidator($this->loggerMock);
+        $validator->processFile($parser);
+
+        $reflection = new \ReflectionClass($validator);
+        $valuesArrayProperty = $reflection->getProperty('valuesArray');
+        $valuesArrayProperty->setAccessible(true);
+        $valuesArray = $valuesArrayProperty->getValue($validator);
+
+        $this->assertArrayHasKey('test.xlf', $valuesArray);
+        $this->assertArrayHasKey('valueA', $valuesArray['test.xlf']);
+        $this->assertArrayHasKey('valueB', $valuesArray['test.xlf']);
+        $this->assertArrayHasKey('valueC', $valuesArray['test.xlf']);
+        $this->assertSame(['key1'], $valuesArray['test.xlf']['valueA']);
+        $this->assertSame(['key2'], $valuesArray['test.xlf']['valueB']);
+        $this->assertSame(['key3'], $valuesArray['test.xlf']['valueC']);
+    }
+
+    public function testProcessFileWithInvalidFile(): void
+    {
+        $parser = $this->createMock(ParserInterface::class);
+        $parser->method('extractKeys')->willReturn(null);
+        $parser->method('getFileName')->willReturn('invalid.xlf');
+
+        $this->loggerMock->expects($this->once())
+            ->method('error')
+            ->with($this->stringContains('The source file invalid.xlf is not valid.'));
+
+        $validator = new DuplicateValuesValidator($this->loggerMock);
+        $validator->processFile($parser);
+
+        $reflection = new \ReflectionClass($validator);
+        $valuesArrayProperty = $reflection->getProperty('valuesArray');
+        $valuesArrayProperty->setAccessible(true);
+        $valuesArray = $valuesArrayProperty->getValue($validator);
+
+        $this->assertEmpty($valuesArray);
+    }
+
+    public function testPostProcessWithDuplicateValues(): void
+    {
+        $validator = new DuplicateValuesValidator($this->loggerMock);
+
+        // Manually set valuesArray to simulate previous processFile calls
+        $reflection = new \ReflectionClass($validator);
+        $valuesArrayProperty = $reflection->getProperty('valuesArray');
+        $valuesArrayProperty->setAccessible(true);
+        $valuesArrayProperty->setValue($validator, [
+            'file1.xlf' => [
+                'valueA' => ['key1', 'key3'],
+                'valueB' => ['key2'],
+            ],
+            'file2.xlf' => [
+                'valueX' => ['keyA', 'keyB'],
+            ],
+        ]);
+
+        $validator->postProcess();
+
+        $issuesProperty = $reflection->getProperty('issues');
+        $issuesProperty->setAccessible(true);
+        $issues = $issuesProperty->getValue($validator);
+
+        $expectedIssues = [
+            [
+                'file' => 'file1.xlf',
+                'issues' => [
+                    'valueA' => ['key1', 'key3'],
+                ],
+            ],
+            [
+                'file' => 'file2.xlf',
+                'issues' => [
+                    'valueX' => ['keyA', 'keyB'],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expectedIssues, $issues);
+    }
+
+    public function testPostProcessWithoutDuplicateValues(): void
+    {
+        $validator = new DuplicateValuesValidator($this->loggerMock);
+
+        // Manually set valuesArray with no duplicates
+        $reflection = new \ReflectionClass($validator);
+        $valuesArrayProperty = $reflection->getProperty('valuesArray');
+        $valuesArrayProperty->setAccessible(true);
+        $valuesArrayProperty->setValue($validator, [
+            'file1.xlf' => [
+                'valueA' => ['key1'],
+                'valueB' => ['key2'],
+            ],
+        ]);
+
+        $validator->postProcess();
+
+        $issuesProperty = $reflection->getProperty('issues');
+        $issuesProperty->setAccessible(true);
+        $issues = $issuesProperty->getValue($validator);
+
+        $this->assertEmpty($issues);
+    }
+
+    public function testRenderIssueSets(): void
+    {
+        $input = $this->createMock(InputInterface::class);
+        $output = new BufferedOutput();
+
+        $issueSets = [
+            [
+                'file' => 'file1.xlf',
+                'issues' => [
+                    'valueA' => ['key1', 'key3'],
+                ],
+            ],
+            [
+                'file' => 'file2.xlf',
+                'issues' => [
+                    'valueX' => ['keyA', 'keyB'],
+                ],
+            ],
+        ];
+
+        $validator = new DuplicateValuesValidator($this->loggerMock);
+        $validator->renderIssueSets($input, $output, $issueSets);
+
+        $expectedOutput = <<<'EOT'
++-----------+------+--------+
+| File      | Key  | Value  |
++-----------+------+--------+
+| file1.xlf | key1 | valueA |
+|           | key3 |        |
++-----------+------+--------+
+| file2.xlf | keyA | valueX |
+|           | keyB |        |
++-----------+------+--------+
+EOT;
+
+        $this->assertSame(trim($expectedOutput), trim($output->fetch()));
+    }
+
+    public function testExplain(): void
+    {
+        $validator = new DuplicateValuesValidator($this->loggerMock);
+        $this->assertIsString($validator->explain());
+        $this->assertStringContainsString('duplicate values', $validator->explain());
+    }
+
+    public function testSupportsParser(): void
+    {
+        $validator = new DuplicateValuesValidator($this->loggerMock);
+        $supportedParsers = $validator->supportsParser();
+
+        $this->assertContains(XliffParser::class, $supportedParsers);
+        $this->assertContains(YamlParser::class, $supportedParsers);
+    }
+
+    public function testResultTypeOnValidationFailure(): void
+    {
+        $validator = new DuplicateValuesValidator($this->loggerMock);
+        $this->assertSame(ResultType::WARNING, $validator->resultTypeOnValidationFailure());
+    }
+}

--- a/tests/src/Validator/DuplicateValuesValidatorTest.php
+++ b/tests/src/Validator/DuplicateValuesValidatorTest.php
@@ -173,16 +173,20 @@ final class DuplicateValuesValidatorTest extends TestCase
         $output = new BufferedOutput();
 
         $issueSets = [
-            [
-                'file' => 'file1.xlf',
-                'issues' => [
-                    'valueA' => ['key1', 'key3'],
+            'file1.xlf' => [
+                [
+                    'file' => 'file1.xlf',
+                    'issues' => [
+                        'valueA' => ['key1', 'key3'],
+                    ],
                 ],
             ],
-            [
-                'file' => 'file2.xlf',
-                'issues' => [
-                    'valueX' => ['keyA', 'keyB'],
+            'file2.xlf' => [
+                [
+                    'file' => 'file2.xlf',
+                    'issues' => [
+                        'valueX' => ['keyA', 'keyB'],
+                    ],
                 ],
             ],
         ];
@@ -208,7 +212,6 @@ EOT;
     public function testExplain(): void
     {
         $validator = new DuplicateValuesValidator($this->loggerMock);
-        $this->assertIsString($validator->explain());
         $this->assertStringContainsString('duplicate values', $validator->explain());
     }
 

--- a/tests/src/Validator/ValidatorRegistryTest.php
+++ b/tests/src/Validator/ValidatorRegistryTest.php
@@ -19,6 +19,6 @@ final class ValidatorRegistryTest extends TestCase
         $this->assertContains(MismatchValidator::class, $validators);
         $this->assertContains(DuplicateKeysValidator::class, $validators);
         $this->assertContains(SchemaValidator::class, $validators);
-        $this->assertCount(3, $validators);
+        $this->assertCount(4, $validators);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a validator that detects duplicate translation values assigned to different keys within the same file, reporting these as warnings.
* **Bug Fixes**
  * Improved message display logic to distinguish between warnings and errors based on result type and dry run status.
* **Tests**
  * Added comprehensive tests for the new duplicate values validator.
  * Updated existing tests and fixtures to cover new validation logic and ensure accurate validator registration.
* **Chores**
  * Enhanced test output configuration for better visibility of warnings.
* **Documentation**
  * Updated README to clarify supported translation formats with framework context.
  * Added details on validator severity levels and introduced the new duplicate values validator in documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->