### PR TITLE
feat: enhance validation command options to allow skipping and specifying validators

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ composer validate-translations [<path>]
 The command `validate-translations` can be used to validate translation files in your project. It will automatically detect the translation files based on the supported formats and run the configured validators.
 
 ```bash
-composer validate-translations [<path>] [-dr|--dry-run] [-f|--format cli|json] [-e|--exclude PATTERN] [-v|--verbose]
+composer validate-translations [<path>] [-dr|--dry-run] [-f|--format cli|json] [-e|--exclude PATTERN] [-s|--skip VALIDATOR] [-o|--only VALIDATOR] [-v|--verbose]
 ```
 
 ## 📝 Documentation

--- a/src/Command/ValidateTranslationCommand.php
+++ b/src/Command/ValidateTranslationCommand.php
@@ -75,10 +75,16 @@ class ValidateTranslationCommand extends BaseCommand
                 'The file detector to use (FQCN)'
             )
             ->addOption(
-                'validator',
-                'vd',
+                'only',
+                'o',
                 InputOption::VALUE_OPTIONAL,
-                'The specific validator to use (FQCN)'
+                'The specific validators to use (FQCN), comma-separated'
+            )
+            ->addOption(
+                'skip',
+                's',
+                InputOption::VALUE_OPTIONAL,
+                'Skip specific validators (FQCN), comma-separated'
             );
     }
 
@@ -99,8 +105,9 @@ class ValidateTranslationCommand extends BaseCommand
         $this->strict = $input->getOption('strict');
         $excludePatterns = $input->getOption('exclude');
 
-        $fileDetector = $this->validateAndInstantiate(
+        $fileDetector = ClassUtility::instantiate(
             DetectorInterface::class,
+            $this->logger,
             'file detector',
             $input->getOption('file-detector')
         );
@@ -118,28 +125,7 @@ class ValidateTranslationCommand extends BaseCommand
             return Command::SUCCESS;
         }
 
-        if (!ClassUtility::validateClass(
-            ValidatorInterface::class,
-            $this->logger,
-            $input->getOption('validator'))
-        ) {
-            $this->io->error(
-                sprintf('The validator class "%s" must implement %s.',
-                    $input->getOption('validator'),
-                    ValidatorInterface::class
-                )
-            );
-
-            return Command::FAILURE;
-        }
-
-        $this->validateAndInstantiate(
-            ValidatorInterface::class,
-            'validator',
-            $input->getOption('validator')
-        );
-
-        $validators = $input->getOption('validator') ? [$input->getOption('validator')] : ValidatorRegistry::getAvailableValidators();
+        $validators = $this->resolveValidators($input);
         $issues = [];
 
         // ToDo: Simplify this nested loop structure
@@ -178,20 +164,54 @@ class ValidateTranslationCommand extends BaseCommand
         ))->summarize();
     }
 
-    private function validateAndInstantiate(string $interface, string $type, ?string $className = null): ?object
+    /**
+     * @return array<int, class-string<ValidatorInterface>>
+     */
+    private function resolveValidators(InputInterface $input): array
+    {
+        $only = $this->validateClassInput(
+            ValidatorInterface::class,
+            'validator',
+            $input->getOption('only')
+        );
+        $skip = $this->validateClassInput(
+            ValidatorInterface::class,
+            'validator',
+            $input->getOption('skip')
+        );
+
+        if (!empty($only)) {
+            $validators = $only;
+        } elseif (!empty($skip)) {
+            $validators = array_diff(ValidatorRegistry::getAvailableValidators(), $skip);
+        } else {
+            $validators = ValidatorRegistry::getAvailableValidators();
+        }
+
+        return $validators;
+    }
+
+    /**
+     * @return array<int, class-string>
+     */
+    private function validateClassInput(string $interface, string $type, ?string $className = null): array
     {
         if (null === $className) {
-            return null;
+            return [];
+        }
+        $classes = [];
+
+        if (str_contains(',', $className)) {
+            $classNames = explode(',', $className);
+            foreach ($classNames as $name) {
+                ClassUtility::instantiate($interface, $this->logger, $type, $name);
+                $classes[] = $name;
+            }
+        } else {
+            ClassUtility::instantiate($interface, $this->logger, $type, $className);
+            $classes[] = $className;
         }
 
-        if (!ClassUtility::validateClass($interface, $this->logger, $className)) {
-            $this->io->error(
-                sprintf('The %s class "%s" must implement %s.', $type, $className, $interface)
-            );
-
-            return null;
-        }
-
-        return new $className();
+        return $classes;
     }
 }

--- a/src/Command/ValidateTranslationCommand.php
+++ b/src/Command/ValidateTranslationCommand.php
@@ -201,7 +201,7 @@ class ValidateTranslationCommand extends BaseCommand
         }
         $classes = [];
 
-        if (str_contains(',', $className)) {
+        if (str_contains($className, ',')) {
             $classNames = explode(',', $className);
             foreach ($classNames as $name) {
                 ClassUtility::instantiate($interface, $this->logger, $type, $name);

--- a/src/Utility/ClassUtility.php
+++ b/src/Utility/ClassUtility.php
@@ -8,6 +8,23 @@ use Psr\Log\LoggerInterface;
 
 class ClassUtility
 {
+    public static function instantiate(string $interface, LoggerInterface $logger, string $type, ?string $className = null): ?object
+    {
+        if (null === $className) {
+            return null;
+        }
+
+        if (!self::validateClass($interface, $logger, $className)) {
+            $logger->error(
+                sprintf('The %s class "%s" must implement %s.', $type, $className, $interface)
+            );
+
+            return null;
+        }
+
+        return new $className();
+    }
+
     public static function validateClass(string $interface, LoggerInterface $logger, ?string $class): bool
     {
         if (is_null($class)) {

--- a/tests/src/Command/ValidateTranslationCommandTest.php
+++ b/tests/src/Command/ValidateTranslationCommandTest.php
@@ -71,13 +71,18 @@ class ValidateTranslationCommandTest extends TestCase
         $command = $application->find('validate-translations');
         $commandTester = new CommandTester($command);
 
-        $commandTester->execute([
-            'path' => [__DIR__.'/../Fixtures/translations/xliff/success'],
-            '--validator' => 'Invalid\\Validator\\Class',
-        ]);
-
-        $this->assertStringContainsString('must implement', $commandTester->getDisplay());
-        $this->assertSame(1, $commandTester->getStatusCode());
+        try {
+            $commandTester->execute([
+                'path' => [__DIR__.'/../Fixtures/translations/xliff/success'],
+                '--only' => 'Invalid\\Validator\\Class',
+            ]);
+            $this->fail('Expected exception was not thrown.');
+        } catch (\Throwable $e) {
+            $this->assertStringContainsString(
+                'Class "Invalid\Validator\Class" not found',
+                $e->getMessage()
+            );
+        }
     }
 
     public function testExecuteWithErrors(): void
@@ -237,7 +242,7 @@ class ValidateTranslationCommandTest extends TestCase
 
         $commandTester->execute([
             'path' => [__DIR__.'/../Fixtures/translations/xliff/success'],
-            '--validator' => null,
+            '--skip' => null,
         ]);
 
         $this->assertStringContainsString('Language validation succeeded.', $commandTester->getDisplay());

--- a/tests/src/Utility/ClassUtilityTest.php
+++ b/tests/src/Utility/ClassUtilityTest.php
@@ -69,7 +69,7 @@ final class ClassUtilityTest extends TestCase
     {
         $loggedMessages = [];
         $logger = $this->createMock(LoggerInterface::class);
-        $logger->method('error')->willReturnCallback(function ($message) use (&$loggedMessages) {
+        $logger->method('error')->willReturnCallback(function (string|\Stringable $message) use (&$loggedMessages): void {
             $loggedMessages[] = $message;
         });
 
@@ -83,7 +83,7 @@ final class ClassUtilityTest extends TestCase
     {
         $loggedMessages = [];
         $logger = $this->createMock(LoggerInterface::class);
-        $logger->method('error')->willReturnCallback(function ($message) use (&$loggedMessages) {
+        $logger->method('error')->willReturnCallback(function (string|\Stringable $message) use (&$loggedMessages): void {
             $loggedMessages[] = $message;
         });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying multiple validators to include or skip when running translation validation commands, using new `--only` and `--skip` options.

* **Documentation**
  * Updated usage instructions in the README to reflect new validator selection options.

* **Tests**
  * Improved test coverage for validator selection, including handling of invalid or null validator inputs.
  * Added tests for class instantiation utility covering validation and error logging scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->