### PR TITLE
fix: replace XmlUtils::loadFile with file_get_contents to avoid autoloading issues

### DIFF
--- a/src/Validator/SchemaValidator.php
+++ b/src/Validator/SchemaValidator.php
@@ -19,7 +19,17 @@ class SchemaValidator extends AbstractValidator implements ValidatorInterface
     public function processFile(ParserInterface $file): array
     {
         try {
-            $dom = XmlUtils::loadFile($file->getFilePath());
+            /*
+             * With XmlUtils::loadFile() we always get a strange symfony error related to global composer autoloading issue.
+             *      Call to undefined method Symfony\Component\Filesystem\Filesystem::readFile()
+             */
+            $fileContent = file_get_contents($file->getFilePath());
+            if (false === $fileContent) {
+                $this->logger?->error('Failed to read file: '.$file->getFileName());
+
+                return [];
+            }
+            $dom = XmlUtils::parse($fileContent);
             $errors = XliffUtils::validateSchema($dom);
         } catch (\Exception $e) {
             $this->logger?->error('Failed to validate XML schema: '.$e->getMessage());

--- a/src/Validator/SchemaValidator.php
+++ b/src/Validator/SchemaValidator.php
@@ -23,6 +23,12 @@ class SchemaValidator extends AbstractValidator implements ValidatorInterface
              * With XmlUtils::loadFile() we always get a strange symfony error related to global composer autoloading issue.
              *      Call to undefined method Symfony\Component\Filesystem\Filesystem::readFile()
              */
+            if (!file_exists($file->getFilePath())) {
+                $this->logger?->error('File does not exist: '.$file->getFileName());
+
+                return [];
+            }
+
             $fileContent = file_get_contents($file->getFilePath());
             if (false === $fileContent) {
                 $this->logger?->error('Failed to read file: '.$file->getFileName());

--- a/tests/src/Validator/SchemaValidatorTest.php
+++ b/tests/src/Validator/SchemaValidatorTest.php
@@ -109,7 +109,7 @@ EOT
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects($this->once())
             ->method('error')
-            ->with($this->stringContains('Failed to validate XML schema: '));
+            ->with($this->stringContains('File does not exist'));
 
         $validator = new SchemaValidator($logger);
         $result = $validator->processFile($parser);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of XML file validation by enhancing error handling for missing or unreadable files during schema validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->