### PR TITLE
feat: add PlaceholderConsistencyValidator for validating placeholder consistency across translation files

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ The following validators are available:
 | `DuplicateKeysValidator`   | This validator checks for duplicate keys in translation files.                                                                                                           | XLIFF       | ERROR   |
 | `DuplicateValuesValidator` | This validator checks for duplicate values in translation files.                                                                                                         | XLIFF, Yaml     | WARNING |
 | `XliffSchemaValidator`          | Validates the XML schema of translation files against the XLIFF standard. See available [schemas](https://github.com/symfony/translation/tree/6.4/Resources/schemas).    | XLIFF       | ERROR   |
+| `PlaceholderConsistencyValidator`                                | Validates placeholder consistency across files.                                                                                                                          | XLIFF, Yaml     | WARNING |
 
 
 ## 🧑‍💻 Contributing

--- a/src/Command/ValidateTranslationCommand.php
+++ b/src/Command/ValidateTranslationCommand.php
@@ -104,7 +104,8 @@ using multiple validators to ensure consistency, correctness and schema complian
   • <info>MismatchValidator</info>        - Detects mismatches between source and target
   • <info>DuplicateKeysValidator</info>   - Finds duplicate translation keys
   • <info>DuplicateValuesValidator</info> - Finds duplicate translation values
-  • <info>XliffSchemaValidator</info>          - Validates XLIFF schema compliance
+  • <info>PlaceholderConsistencyValidator</info> - Validates placeholder consistency across files
+  • <info>XliffSchemaValidator</info>     - Validates XLIFF schema compliance
 
 <comment>Configuration:</comment>
 You can configure the validator using:

--- a/src/Result/ValidationResultCliRenderer.php
+++ b/src/Result/ValidationResultCliRenderer.php
@@ -42,6 +42,18 @@ class ValidationResultCliRenderer extends AbstractValidationResultRenderer
         return $this->calculateExitCode($validationResult);
     }
 
+    private function renderHeader(): void
+    {
+        $this->io->title('Composer Translation Validator');
+        $this->io->text([
+            'A comprehensive tool for validating translation files (XLIFF and YAML).',
+            'Checks for mismatches, duplicates, placeholder consistency and schema compliance.',
+            '',
+            'For more information and usage examples, run: <fg=cyan>composer validate-translations --help</>',
+        ]);
+        $this->io->newLine();
+    }
+
     private function renderCompactOutput(ValidationResult $validationResult): void
     {
         $groupedByFile = $this->groupIssuesByFile($validationResult);
@@ -105,6 +117,8 @@ class ValidationResultCliRenderer extends AbstractValidationResultRenderer
 
     private function renderVerboseOutput(ValidationResult $validationResult): void
     {
+        $this->renderHeader();
+
         $groupedByFile = $this->groupIssuesByFile($validationResult);
 
         if (empty($groupedByFile)) {

--- a/src/Validator/PlaceholderConsistencyValidator.php
+++ b/src/Validator/PlaceholderConsistencyValidator.php
@@ -1,0 +1,304 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoveElevator\ComposerTranslationValidator\Validator;
+
+use MoveElevator\ComposerTranslationValidator\FileDetector\FileSet;
+use MoveElevator\ComposerTranslationValidator\Parser\ParserInterface;
+use MoveElevator\ComposerTranslationValidator\Parser\XliffParser;
+use MoveElevator\ComposerTranslationValidator\Parser\YamlParser;
+use MoveElevator\ComposerTranslationValidator\Result\Issue;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Helper\TableStyle;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class PlaceholderConsistencyValidator extends AbstractValidator implements ValidatorInterface
+{
+    /** @var array<string, array<string, array{value: string, placeholders: array<string>}>> */
+    protected array $keyData = [];
+
+    public function processFile(ParserInterface $file): array
+    {
+        $keys = $file->extractKeys();
+
+        if (null === $keys) {
+            $this->logger?->error(
+                'The source file '.$file->getFileName().' is not valid.'
+            );
+
+            return [];
+        }
+
+        foreach ($keys as $key) {
+            $value = $file->getContentByKey($key);
+            if (null === $value) {
+                continue;
+            }
+
+            $placeholders = $this->extractPlaceholders($value);
+            $this->keyData[$key][$file->getFileName()] = [
+                'value' => $value,
+                'placeholders' => $placeholders,
+            ];
+        }
+
+        return [];
+    }
+
+    public function postProcess(): void
+    {
+        foreach ($this->keyData as $key => $fileData) {
+            $placeholderInconsistencies = $this->findPlaceholderInconsistencies($fileData);
+
+            if (!empty($placeholderInconsistencies)) {
+                $result = [
+                    'key' => $key,
+                    'files' => $fileData,
+                    'inconsistencies' => $placeholderInconsistencies,
+                ];
+
+                $this->addIssue(new Issue(
+                    '',
+                    $result,
+                    '',
+                    $this->getShortName()
+                ));
+            }
+        }
+    }
+
+    /**
+     * Extract placeholders from a translation value
+     * Supports various placeholder syntaxes:
+     * - %parameter% (Symfony style)
+     * - {parameter} (ICU MessageFormat style)
+     * - {{ parameter }} (Twig style)
+     * - %s, %d, %1$s (printf style)
+     * - :parameter (Laravel style).
+     *
+     * @return array<string>
+     */
+    private function extractPlaceholders(string $value): array
+    {
+        $placeholders = [];
+
+        // Symfony style: %parameter%
+        if (preg_match_all('/%([a-zA-Z_][a-zA-Z0-9_]*)%/', $value, $matches)) {
+            foreach ($matches[1] as $match) {
+                $placeholders[] = "%{$match}%";
+            }
+        }
+
+        // ICU MessageFormat style: {parameter}
+        if (preg_match_all('/\{([a-zA-Z_][a-zA-Z0-9_]*)\}/', $value, $matches)) {
+            foreach ($matches[1] as $match) {
+                $placeholders[] = "{{$match}}";
+            }
+        }
+
+        // Twig style: {{ parameter }}
+        if (preg_match_all('/\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/', $value, $matches)) {
+            foreach ($matches[1] as $match) {
+                $placeholders[] = "{{ {$match} }}";
+            }
+        }
+
+        // Printf style: %s, %d, %1$s, etc.
+        if (preg_match_all('/%(?:(\d+)\$)?[sdcoxXeEfFgGaA]/', $value, $matches)) {
+            foreach ($matches[0] as $match) {
+                $placeholders[] = $match;
+            }
+        }
+
+        // Laravel style: :parameter
+        if (preg_match_all('/:([a-zA-Z_][a-zA-Z0-9_]*)/', $value, $matches)) {
+            foreach ($matches[1] as $match) {
+                $placeholders[] = ":{$match}";
+            }
+        }
+
+        return array_unique($placeholders);
+    }
+
+    /**
+     * @param array<string, array{value: string, placeholders: array<string>}> $fileData
+     *
+     * @return array<string>
+     */
+    private function findPlaceholderInconsistencies(array $fileData): array
+    {
+        if (count($fileData) < 2) {
+            return [];
+        }
+
+        $inconsistencies = [];
+        $allPlaceholders = [];
+
+        // Collect all placeholders from all files for this key
+        foreach ($fileData as $fileName => $data) {
+            $allPlaceholders[$fileName] = $data['placeholders'];
+        }
+
+        // Compare placeholders between files
+        $fileNames = array_keys($allPlaceholders);
+        $referenceFile = $fileNames[0];
+        $referencePlaceholders = $allPlaceholders[$referenceFile];
+
+        for ($i = 1, $iMax = count($fileNames); $i < $iMax; ++$i) {
+            $currentFile = $fileNames[$i];
+            $currentPlaceholders = $allPlaceholders[$currentFile];
+
+            $missing = array_diff($referencePlaceholders, $currentPlaceholders);
+            $extra = array_diff($currentPlaceholders, $referencePlaceholders);
+
+            if (!empty($missing)) {
+                $inconsistencies[] = "File '{$currentFile}' is missing placeholders: ".implode(', ', $missing);
+            }
+
+            if (!empty($extra)) {
+                $inconsistencies[] = "File '{$currentFile}' has extra placeholders: ".implode(', ', $extra);
+            }
+        }
+
+        return $inconsistencies;
+    }
+
+    public function formatIssueMessage(Issue $issue, string $prefix = ''): string
+    {
+        $details = $issue->getDetails();
+        $resultType = $this->resultTypeOnValidationFailure();
+
+        $level = $resultType->toString();
+        $color = $resultType->toColorString();
+
+        $key = $details['key'] ?? 'unknown';
+        $inconsistencies = $details['inconsistencies'] ?? [];
+
+        $inconsistencyText = implode('; ', $inconsistencies);
+
+        return "- <fg={$color}>{$level}</> {$prefix}placeholder inconsistency in translation key `{$key}` - {$inconsistencyText}";
+    }
+
+    public function distributeIssuesForDisplay(FileSet $fileSet): array
+    {
+        $distribution = [];
+
+        foreach ($this->issues as $issue) {
+            $details = $issue->getDetails();
+            $files = $details['files'] ?? [];
+
+            foreach ($files as $fileName => $fileInfo) {
+                if (!empty($fileName)) {
+                    $basePath = rtrim($fileSet->getPath(), '/');
+                    $filePath = $basePath.'/'.$fileName;
+
+                    $fileSpecificIssue = new Issue(
+                        $filePath,
+                        $details,
+                        $issue->getParser(),
+                        $issue->getValidatorType()
+                    );
+
+                    $distribution[$filePath] ??= [];
+                    $distribution[$filePath][] = $fileSpecificIssue;
+                }
+            }
+        }
+
+        return $distribution;
+    }
+
+    public function renderDetailedOutput(OutputInterface $output, array $issues): void
+    {
+        if (empty($issues)) {
+            return;
+        }
+
+        $rows = [];
+        $allKeys = [];
+        $allFilesData = [];
+
+        foreach ($issues as $issue) {
+            $details = $issue->getDetails();
+            $key = $details['key'] ?? 'unknown';
+            $files = $details['files'] ?? [];
+
+            if (!in_array($key, $allKeys)) {
+                $allKeys[] = $key;
+            }
+
+            foreach ($files as $fileName => $fileInfo) {
+                $value = $fileInfo['value'] ?? '';
+                if (!isset($allFilesData[$key])) {
+                    $allFilesData[$key] = [];
+                }
+                $allFilesData[$key][$fileName] = $value;
+            }
+        }
+
+        $firstIssue = $issues[0];
+        $firstDetails = $firstIssue->getDetails();
+        $firstFiles = $firstDetails['files'] ?? [];
+
+        $fileOrder = array_keys($firstFiles);
+
+        $header = ['Translation Key'];
+        foreach ($fileOrder as $fileName) {
+            $header[] = $fileName;
+        }
+
+        foreach ($allKeys as $key) {
+            $row = [$key];
+            foreach ($fileOrder as $fileName) {
+                $value = $allFilesData[$key][$fileName] ?? '';
+                $row[] = $this->highlightPlaceholders($value);
+            }
+            $rows[] = $row;
+        }
+
+        $table = new Table($output);
+        $table->setHeaders($header)
+            ->setRows($rows)
+            ->setStyle(
+                (new TableStyle())
+                    ->setCellHeaderFormat('%s')
+            )
+            ->render();
+    }
+
+    private function highlightPlaceholders(string $value): string
+    {
+        $placeholders = $this->extractPlaceholders($value);
+
+        foreach ($placeholders as $placeholder) {
+            $value = str_replace($placeholder, "<fg=yellow>{$placeholder}</>", $value);
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return class-string<ParserInterface>[]
+     */
+    public function supportsParser(): array
+    {
+        return [XliffParser::class, YamlParser::class];
+    }
+
+    protected function resetState(): void
+    {
+        parent::resetState();
+        $this->keyData = [];
+    }
+
+    public function resultTypeOnValidationFailure(): ResultType
+    {
+        return ResultType::WARNING;
+    }
+
+    public function shouldShowDetailedOutput(): bool
+    {
+        return true;
+    }
+}

--- a/src/Validator/ValidatorRegistry.php
+++ b/src/Validator/ValidatorRegistry.php
@@ -15,6 +15,7 @@ class ValidatorRegistry
             MismatchValidator::class,
             DuplicateKeysValidator::class,
             DuplicateValuesValidator::class,
+            PlaceholderConsistencyValidator::class,
             XliffSchemaValidator::class,
         ];
     }

--- a/tests/src/Fixtures/translations/xliff/fail/locallang.xlf
+++ b/tests/src/Fixtures/translations/xliff/fail/locallang.xlf
@@ -10,7 +10,7 @@
                 <source>English Key #1</source>
             </trans-unit>
             <trans-unit id="key3">
-                <source>English Key #1</source>
+                <source>English Key #1 %s</source>
             </trans-unit>
             <trans-unit id="key2">
                 <source>English Key #2</source>

--- a/tests/src/Validator/PlaceholderConsistencyValidatorTest.php
+++ b/tests/src/Validator/PlaceholderConsistencyValidatorTest.php
@@ -1,0 +1,441 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoveElevator\ComposerTranslationValidator\Tests\Validator;
+
+use MoveElevator\ComposerTranslationValidator\FileDetector\FileSet;
+use MoveElevator\ComposerTranslationValidator\Parser\ParserInterface;
+use MoveElevator\ComposerTranslationValidator\Parser\XliffParser;
+use MoveElevator\ComposerTranslationValidator\Parser\YamlParser;
+use MoveElevator\ComposerTranslationValidator\Result\Issue;
+use MoveElevator\ComposerTranslationValidator\Validator\PlaceholderConsistencyValidator;
+use MoveElevator\ComposerTranslationValidator\Validator\ResultType;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+final class PlaceholderConsistencyValidatorTest extends TestCase
+{
+    public function testProcessFileWithValidFile(): void
+    {
+        $parser = $this->createMock(ParserInterface::class);
+        $parser->method('extractKeys')->willReturn(['key1', 'key2']);
+        $parser->method('getContentByKey')->willReturnMap([
+            ['key1', 'source', 'Hello %name%!'],
+            ['key2', 'source', 'Welcome {user}'],
+        ]);
+        $parser->method('getFileName')->willReturn('test.xlf');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('error');
+
+        $validator = new PlaceholderConsistencyValidator($logger);
+        $result = $validator->processFile($parser);
+
+        // processFile should return empty array as issues are handled in postProcess
+        $this->assertEmpty($result);
+    }
+
+    public function testProcessFileWithInvalidFile(): void
+    {
+        $parser = $this->createMock(ParserInterface::class);
+        $parser->method('extractKeys')->willReturn(null);
+        $parser->method('getFileName')->willReturn('invalid.xlf');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('error')
+            ->with($this->stringContains('The source file invalid.xlf is not valid.'));
+
+        $validator = new PlaceholderConsistencyValidator($logger);
+        $result = $validator->processFile($parser);
+
+        $this->assertEmpty($result);
+    }
+
+    public function testPostProcessWithConsistentPlaceholders(): void
+    {
+        $parser1 = $this->createMock(ParserInterface::class);
+        $parser1->method('extractKeys')->willReturn(['key1']);
+        $parser1->method('getContentByKey')->willReturn('Hello %name%!');
+        $parser1->method('getFileName')->willReturn('en.xlf');
+
+        $parser2 = $this->createMock(ParserInterface::class);
+        $parser2->method('extractKeys')->willReturn(['key1']);
+        $parser2->method('getContentByKey')->willReturn('Hallo %name%!');
+        $parser2->method('getFileName')->willReturn('de.xlf');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $validator = new PlaceholderConsistencyValidator($logger);
+
+        $validator->processFile($parser1);
+        $validator->processFile($parser2);
+        $validator->postProcess();
+
+        $this->assertFalse($validator->hasIssues());
+    }
+
+    public function testPostProcessWithInconsistentPlaceholders(): void
+    {
+        $parser1 = $this->createMock(ParserInterface::class);
+        $parser1->method('extractKeys')->willReturn(['key1']);
+        $parser1->method('getContentByKey')->willReturn('Hello %name%!');
+        $parser1->method('getFileName')->willReturn('en.xlf');
+
+        $parser2 = $this->createMock(ParserInterface::class);
+        $parser2->method('extractKeys')->willReturn(['key1']);
+        $parser2->method('getContentByKey')->willReturn('Hallo %username%!');
+        $parser2->method('getFileName')->willReturn('de.xlf');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $validator = new PlaceholderConsistencyValidator($logger);
+
+        $validator->processFile($parser1);
+        $validator->processFile($parser2);
+        $validator->postProcess();
+
+        $this->assertTrue($validator->hasIssues());
+        $issues = $validator->getIssues();
+        $this->assertCount(1, $issues);
+    }
+
+    public function testExtractSymfonyStylePlaceholders(): void
+    {
+        $parser = $this->createMock(ParserInterface::class);
+        $parser->method('extractKeys')->willReturn(['key1']);
+        $parser->method('getContentByKey')->willReturn('Hello %name% and %surname%!');
+        $parser->method('getFileName')->willReturn('test.xlf');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $validator = new PlaceholderConsistencyValidator($logger);
+
+        $reflectionClass = new \ReflectionClass($validator);
+        $method = $reflectionClass->getMethod('extractPlaceholders');
+        $method->setAccessible(true);
+
+        $placeholders = $method->invoke($validator, 'Hello %name% and %surname%!');
+        $this->assertContains('%name%', $placeholders);
+        $this->assertContains('%surname%', $placeholders);
+        // Verify that we have exactly these placeholders (excluding potential false matches)
+        $expectedPlaceholders = ['%name%', '%surname%'];
+        $this->assertEmpty(array_diff($expectedPlaceholders, $placeholders));
+    }
+
+    public function testExtractIcuStylePlaceholders(): void
+    {
+        $parser = $this->createMock(ParserInterface::class);
+        $parser->method('extractKeys')->willReturn(['key1']);
+        $parser->method('getContentByKey')->willReturn('Hello {name} and {surname}!');
+        $parser->method('getFileName')->willReturn('test.xlf');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $validator = new PlaceholderConsistencyValidator($logger);
+
+        $reflectionClass = new \ReflectionClass($validator);
+        $method = $reflectionClass->getMethod('extractPlaceholders');
+        $method->setAccessible(true);
+
+        $placeholders = $method->invoke($validator, 'Hello {name} and {surname}!');
+        $this->assertContains('{name}', $placeholders);
+        $this->assertContains('{surname}', $placeholders);
+        $this->assertCount(2, $placeholders);
+    }
+
+    public function testExtractTwigStylePlaceholders(): void
+    {
+        $parser = $this->createMock(ParserInterface::class);
+        $parser->method('extractKeys')->willReturn(['key1']);
+        $parser->method('getContentByKey')->willReturn('Hello {{ name }} and {{ surname }}!');
+        $parser->method('getFileName')->willReturn('test.xlf');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $validator = new PlaceholderConsistencyValidator($logger);
+
+        $reflectionClass = new \ReflectionClass($validator);
+        $method = $reflectionClass->getMethod('extractPlaceholders');
+        $method->setAccessible(true);
+
+        $placeholders = $method->invoke($validator, 'Hello {{ name }} and {{ surname }}!');
+        $this->assertContains('{{ name }}', $placeholders);
+        $this->assertContains('{{ surname }}', $placeholders);
+        $this->assertCount(2, $placeholders);
+    }
+
+    public function testExtractPrintfStylePlaceholders(): void
+    {
+        $parser = $this->createMock(ParserInterface::class);
+        $parser->method('extractKeys')->willReturn(['key1']);
+        $parser->method('getContentByKey')->willReturn('Hello %s and %1$s!');
+        $parser->method('getFileName')->willReturn('test.xlf');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $validator = new PlaceholderConsistencyValidator($logger);
+
+        $reflectionClass = new \ReflectionClass($validator);
+        $method = $reflectionClass->getMethod('extractPlaceholders');
+        $method->setAccessible(true);
+
+        $placeholders = $method->invoke($validator, 'Hello %s and %1$s!');
+        $this->assertContains('%s', $placeholders);
+        $this->assertContains('%1$s', $placeholders);
+        $this->assertCount(2, $placeholders);
+    }
+
+    public function testExtractLaravelStylePlaceholders(): void
+    {
+        $parser = $this->createMock(ParserInterface::class);
+        $parser->method('extractKeys')->willReturn(['key1']);
+        $parser->method('getContentByKey')->willReturn('Hello :name and :surname!');
+        $parser->method('getFileName')->willReturn('test.xlf');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $validator = new PlaceholderConsistencyValidator($logger);
+
+        $reflectionClass = new \ReflectionClass($validator);
+        $method = $reflectionClass->getMethod('extractPlaceholders');
+        $method->setAccessible(true);
+
+        $placeholders = $method->invoke($validator, 'Hello :name and :surname!');
+        $this->assertContains(':name', $placeholders);
+        $this->assertContains(':surname', $placeholders);
+        $this->assertCount(2, $placeholders);
+    }
+
+    public function testExtractMixedStylePlaceholders(): void
+    {
+        $parser = $this->createMock(ParserInterface::class);
+        $parser->method('extractKeys')->willReturn(['key1']);
+        $parser->method('getContentByKey')->willReturn('Hello %name% and {user} with %s!');
+        $parser->method('getFileName')->willReturn('test.xlf');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $validator = new PlaceholderConsistencyValidator($logger);
+
+        $reflectionClass = new \ReflectionClass($validator);
+        $method = $reflectionClass->getMethod('extractPlaceholders');
+        $method->setAccessible(true);
+
+        $placeholders = $method->invoke($validator, 'Hello %name% and {user} with %s!');
+        $this->assertContains('%name%', $placeholders);
+        $this->assertContains('{user}', $placeholders);
+        $this->assertContains('%s', $placeholders);
+        $this->assertCount(3, $placeholders);
+    }
+
+    public function testSupportsParser(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $validator = new PlaceholderConsistencyValidator($logger);
+
+        $expectedParsers = [XliffParser::class, YamlParser::class];
+        $this->assertSame($expectedParsers, $validator->supportsParser());
+    }
+
+    public function testGetShortName(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $validator = new PlaceholderConsistencyValidator($logger);
+
+        $this->assertSame('PlaceholderConsistencyValidator', $validator->getShortName());
+    }
+
+    public function testResultTypeOnValidationFailure(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $validator = new PlaceholderConsistencyValidator($logger);
+
+        $this->assertSame(ResultType::WARNING, $validator->resultTypeOnValidationFailure());
+    }
+
+    public function testShouldShowDetailedOutput(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $validator = new PlaceholderConsistencyValidator($logger);
+
+        $this->assertTrue($validator->shouldShowDetailedOutput());
+    }
+
+    public function testFormatIssueMessage(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $validator = new PlaceholderConsistencyValidator($logger);
+
+        $issue = new Issue(
+            'test.xlf',
+            [
+                'key' => 'test.key',
+                'inconsistencies' => [
+                    "File 'de.xlf' is missing placeholders: %name%",
+                    "File 'de.xlf' has extra placeholders: %username%",
+                ],
+            ],
+            'XliffParser',
+            'PlaceholderConsistencyValidator'
+        );
+
+        $result = $validator->formatIssueMessage($issue);
+
+        $this->assertStringContainsString('Warning', $result);
+        $this->assertStringContainsString('<fg=yellow>', $result);
+        $this->assertStringContainsString('test.key', $result);
+        $this->assertStringContainsString('missing placeholders: %name%', $result);
+        $this->assertStringContainsString('extra placeholders: %username%', $result);
+    }
+
+    public function testFormatIssueMessageWithPrefix(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $validator = new PlaceholderConsistencyValidator($logger);
+
+        $issue = new Issue(
+            'test.xlf',
+            [
+                'key' => 'test.key',
+                'inconsistencies' => ['Some inconsistency'],
+            ],
+            'XliffParser',
+            'PlaceholderConsistencyValidator'
+        );
+
+        $result = $validator->formatIssueMessage($issue, '(TestPrefix) ');
+
+        $this->assertStringContainsString('(TestPrefix)', $result);
+        $this->assertStringContainsString('test.key', $result);
+    }
+
+    public function testDistributeIssuesForDisplay(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $validator = new PlaceholderConsistencyValidator($logger);
+
+        $issue = new Issue(
+            '',
+            [
+                'key' => 'test.key',
+                'files' => [
+                    'en.xlf' => ['value' => 'Hello %name%!', 'placeholders' => ['%name%']],
+                    'de.xlf' => ['value' => 'Hallo %username%!', 'placeholders' => ['%username%']],
+                ],
+            ],
+            '',
+            'PlaceholderConsistencyValidator'
+        );
+
+        $validator->addIssue($issue);
+
+        $fileSet = new FileSet('XliffParser', '/path/to/files', 'test', []);
+        $distribution = $validator->distributeIssuesForDisplay($fileSet);
+
+        $this->assertArrayHasKey('/path/to/files/en.xlf', $distribution);
+        $this->assertArrayHasKey('/path/to/files/de.xlf', $distribution);
+        $this->assertCount(1, $distribution['/path/to/files/en.xlf']);
+        $this->assertCount(1, $distribution['/path/to/files/de.xlf']);
+    }
+
+    public function testRenderDetailedOutput(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $validator = new PlaceholderConsistencyValidator($logger);
+
+        $issue = new Issue(
+            'test.xlf',
+            [
+                'key' => 'test.key',
+                'files' => [
+                    'en.xlf' => ['value' => 'Hello %name%!', 'placeholders' => ['%name%']],
+                    'de.xlf' => ['value' => 'Hallo %username%!', 'placeholders' => ['%username%']],
+                ],
+                'inconsistencies' => [
+                    "File 'de.xlf' is missing placeholders: %name%",
+                    "File 'de.xlf' has extra placeholders: %username%",
+                ],
+            ],
+            'XliffParser',
+            'PlaceholderConsistencyValidator'
+        );
+
+        $output = new BufferedOutput();
+        $validator->renderDetailedOutput($output, [$issue]);
+
+        $outputContent = $output->fetch();
+        $this->assertStringContainsString('Translation Key', $outputContent);
+        $this->assertStringContainsString('test.key', $outputContent);
+        $this->assertStringContainsString('en.xlf', $outputContent);
+        $this->assertStringContainsString('de.xlf', $outputContent);
+        $this->assertStringContainsString('Hello %name%!', $outputContent);
+        $this->assertStringContainsString('Hallo %username%!', $outputContent);
+    }
+
+    public function testResetState(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $validator = new PlaceholderConsistencyValidator($logger);
+
+        $parser = $this->createMock(ParserInterface::class);
+        $parser->method('extractKeys')->willReturn(['key1']);
+        $parser->method('getContentByKey')->willReturn('Hello %name%!');
+        $parser->method('getFileName')->willReturn('test.xlf');
+
+        $validator->processFile($parser);
+
+        $reflectionClass = new \ReflectionClass($validator);
+        $property = $reflectionClass->getProperty('keyData');
+        $property->setAccessible(true);
+
+        $this->assertNotEmpty($property->getValue($validator));
+
+        $resetMethod = $reflectionClass->getMethod('resetState');
+        $resetMethod->setAccessible(true);
+        $resetMethod->invoke($validator);
+
+        $this->assertEmpty($property->getValue($validator));
+    }
+
+    public function testFindPlaceholderInconsistenciesWithSingleFile(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $validator = new PlaceholderConsistencyValidator($logger);
+
+        $reflectionClass = new \ReflectionClass($validator);
+        $method = $reflectionClass->getMethod('findPlaceholderInconsistencies');
+        $method->setAccessible(true);
+
+        $fileData = [
+            'en.xlf' => ['value' => 'Hello %name%!', 'placeholders' => ['%name%']],
+        ];
+
+        $inconsistencies = $method->invoke($validator, $fileData);
+        $this->assertEmpty($inconsistencies);
+    }
+
+    public function testComplexPlaceholderInconsistencyScenario(): void
+    {
+        $parser1 = $this->createMock(ParserInterface::class);
+        $parser1->method('extractKeys')->willReturn(['greeting', 'farewell']);
+        $parser1->method('getContentByKey')->willReturnMap([
+            ['greeting', 'source', 'Hello %name%! Welcome to {site}'],
+            ['farewell', 'source', 'Goodbye %name%'],
+        ]);
+        $parser1->method('getFileName')->willReturn('en.xlf');
+
+        $parser2 = $this->createMock(ParserInterface::class);
+        $parser2->method('extractKeys')->willReturn(['greeting', 'farewell']);
+        $parser2->method('getContentByKey')->willReturnMap([
+            ['greeting', 'source', 'Hallo %username%! Willkommen bei {site}'],
+            ['farewell', 'source', 'Auf Wiedersehen %name% und %surname%'],
+        ]);
+        $parser2->method('getFileName')->willReturn('de.xlf');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $validator = new PlaceholderConsistencyValidator($logger);
+
+        $validator->processFile($parser1);
+        $validator->processFile($parser2);
+        $validator->postProcess();
+
+        $this->assertTrue($validator->hasIssues());
+        $issues = $validator->getIssues();
+        $this->assertCount(2, $issues); // One for each key with inconsistencies
+    }
+}

--- a/tests/src/Validator/ValidatorRegistryTest.php
+++ b/tests/src/Validator/ValidatorRegistryTest.php
@@ -6,6 +6,7 @@ namespace MoveElevator\ComposerTranslationValidator\Tests\Validator;
 
 use MoveElevator\ComposerTranslationValidator\Validator\DuplicateKeysValidator;
 use MoveElevator\ComposerTranslationValidator\Validator\MismatchValidator;
+use MoveElevator\ComposerTranslationValidator\Validator\PlaceholderConsistencyValidator;
 use MoveElevator\ComposerTranslationValidator\Validator\ValidatorRegistry;
 use MoveElevator\ComposerTranslationValidator\Validator\XliffSchemaValidator;
 use PHPUnit\Framework\TestCase;
@@ -18,8 +19,9 @@ final class ValidatorRegistryTest extends TestCase
 
         $this->assertContains(MismatchValidator::class, $validators);
         $this->assertContains(DuplicateKeysValidator::class, $validators);
+        $this->assertContains(PlaceholderConsistencyValidator::class, $validators);
         $this->assertContains(XliffSchemaValidator::class, $validators);
-        $this->assertCount(4, $validators);
+        $this->assertCount(5, $validators);
     }
 
     public function testGetAvailableValidatorsReturnsArray(): void


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a validator that checks for placeholder consistency across translation files, supporting XLIFF and YAML formats.
  * Added a descriptive header to the verbose output of the validation tool.

* **Documentation**
  * Updated documentation to list the new placeholder consistency validator and its capabilities.

* **Tests**
  * Added comprehensive tests for the new placeholder consistency validator, covering various placeholder styles and scenarios.
  * Updated existing tests to account for the new validator in the registry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->