### PR TITLE
feat: add file headers to all PHP files for licensing and attribution

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -2,16 +2,39 @@
 
 declare(strict_types=1);
 
-$finder = \PhpCsFixer\Finder::create()
-    ->in([__DIR__.'/src', __DIR__.'/tests'])
-    ->exclude('tests/build')
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use EliasHaeussler\PhpCsFixerConfig\Config;
+use EliasHaeussler\PhpCsFixerConfig\Package;
+use EliasHaeussler\PhpCsFixerConfig\Rules;
+use Symfony\Component\Finder;
+
+$header = Rules\Header::create(
+    'composer-translation-validator',
+    Package\Type::ComposerPlugin,
+    Package\Author::create('Konrad Michalik', 'km@move-elevator.de'),
+    Package\CopyrightRange::from(2025),
+    Package\License::GPL3OrLater,
+);
+
+return Config::create()
+    ->withRule($header)
+    ->withFinder(static fn (Finder\Finder $finder) => $finder->in(__DIR__))
 ;
-
-$config = new \PhpCsFixer\Config();
-
-return $config->setRules([
-        '@PSR2' => true,
-        '@Symfony' => true,
-    ])
-    ->setUnsupportedPhpVersionAllowed(true)
-    ->setFinder($finder);

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* km@move-elevator.de

--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,9 @@
 	"require-dev": {
 		"armin/editorconfig-cli": "^1.0 || ^2.0",
 		"composer/composer": "^2.0",
+		"eliashaeussler/php-cs-fixer-config": "2.3.0",
 		"eliashaeussler/rector-config": "^3.0",
 		"ergebnis/composer-normalize": "^2.44",
-		"friendsofphp/php-cs-fixer": "^3.52",
 		"phpstan/phpstan": "^2.0",
 		"phpstan/phpstan-phpunit": "^2.0",
 		"phpstan/phpstan-symfony": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dd69c3c64ff57cbf031254e1adb65bbd",
+    "content-hash": "bb52389c961c3480cbf6d6823f469e50",
     "packages": [
         {
             "name": "justinrainbow/json-schema",
@@ -2057,6 +2057,59 @@
             "time": "2024-05-06T16:37:16+00:00"
         },
         {
+            "name": "eliashaeussler/php-cs-fixer-config",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/eliashaeussler/php-cs-fixer-config.git",
+                "reference": "130111f9aef350910bd2224cd244e6e1b8b5ba82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/eliashaeussler/php-cs-fixer-config/zipball/130111f9aef350910bd2224cd244e6e1b8b5ba82",
+                "reference": "130111f9aef350910bd2224cd244e6e1b8b5ba82",
+                "shasum": ""
+            },
+            "require": {
+                "friendsofphp/php-cs-fixer": "^3.14",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+                "symfony/finder": "^5.4 || ^6.0 || ^7.0"
+            },
+            "require-dev": {
+                "armin/editorconfig-cli": "^1.5 || ^2.0",
+                "eliashaeussler/phpstan-config": "^2.0.0",
+                "eliashaeussler/phpunit-attributes": "^1.1",
+                "eliashaeussler/rector-config": "^3.0",
+                "ergebnis/composer-normalize": "^2.29",
+                "phpstan/extension-installer": "^1.2",
+                "phpunit/phpunit": "^10.4 || ^11.0 || ^12.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "EliasHaeussler\\PhpCsFixerConfig\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Elias Häußler",
+                    "email": "elias@haeussler.dev",
+                    "homepage": "https://haeussler.dev",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "My personal configuration for PHP-CS-Fixer",
+            "support": {
+                "issues": "https://github.com/eliashaeussler/php-cs-fixer-config/issues",
+                "source": "https://github.com/eliashaeussler/php-cs-fixer-config/tree/2.3.0"
+            },
+            "time": "2025-05-18T14:45:22+00:00"
+        },
+        {
             "name": "eliashaeussler/rector-config",
             "version": "3.1.1",
             "source": {
@@ -2675,16 +2728,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.83.0",
+            "version": "v3.84.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "b83916e79a6386a1ec43fdd72391aeb13b63282f"
+                "reference": "38dad0767bf2a9b516b976852200ae722fe984ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/b83916e79a6386a1ec43fdd72391aeb13b63282f",
-                "reference": "b83916e79a6386a1ec43fdd72391aeb13b63282f",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/38dad0767bf2a9b516b976852200ae722fe984ca",
+                "reference": "38dad0767bf2a9b516b976852200ae722fe984ca",
                 "shasum": ""
             },
             "require": {
@@ -2768,7 +2821,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.83.0"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.84.0"
             },
             "funding": [
                 {
@@ -2776,7 +2829,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-07-14T15:41:41+00:00"
+            "time": "2025-07-15T18:21:57+00:00"
         },
         {
             "name": "idiosyncratic/editorconfig",
@@ -3120,16 +3173,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.17",
+            "version": "2.1.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "89b5ef665716fa2a52ecd2633f21007a6a349053"
+                "reference": "ee1f390b7a70cdf74a2b737e554f68afea885db7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/89b5ef665716fa2a52ecd2633f21007a6a349053",
-                "reference": "89b5ef665716fa2a52ecd2633f21007a6a349053",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ee1f390b7a70cdf74a2b737e554f68afea885db7",
+                "reference": "ee1f390b7a70cdf74a2b737e554f68afea885db7",
                 "shasum": ""
             },
             "require": {
@@ -3174,7 +3227,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-05-21T20:55:28+00:00"
+            "time": "2025-07-17T17:22:31+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -4317,21 +4370,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.1.1",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "d0917c069bb0d9bb06ed111cf052510f609015a4"
+                "reference": "40a71441dd73fa150a66102f5ca1364c44fc8fff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/d0917c069bb0d9bb06ed111cf052510f609015a4",
-                "reference": "d0917c069bb0d9bb06ed111cf052510f609015a4",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/40a71441dd73fa150a66102f5ca1364c44fc8fff",
+                "reference": "40a71441dd73fa150a66102f5ca1364c44fc8fff",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.17"
+                "phpstan/phpstan": "^2.1.18"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -4365,7 +4418,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.1.1"
+                "source": "https://github.com/rectorphp/rector/tree/2.1.2"
             },
             "funding": [
                 {
@@ -4373,7 +4426,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-07-10T11:31:31+00:00"
+            "time": "2025-07-17T19:30:06+00:00"
         },
         {
             "name": "roave/security-advisories",
@@ -4381,12 +4434,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "56a0a5fbffe6faa8e85eb4d027a3eaf704adc288"
+                "reference": "5e472fed1bcf8d3a967247576053a20ef3cfefc0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/56a0a5fbffe6faa8e85eb4d027a3eaf704adc288",
-                "reference": "56a0a5fbffe6faa8e85eb4d027a3eaf704adc288",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/5e472fed1bcf8d3a967247576053a20ef3cfefc0",
+                "reference": "5e472fed1bcf8d3a967247576053a20ef3cfefc0",
                 "shasum": ""
             },
             "conflict": {
@@ -4457,6 +4510,7 @@
                 "bednee/cooluri": "<1.0.30",
                 "bigfork/silverstripe-form-capture": ">=3,<3.1.1",
                 "billz/raspap-webgui": "<3.3.6",
+                "binarytorch/larecipe": "<2.8.1",
                 "bk2k/bootstrap-package": ">=7.1,<7.1.2|>=8,<8.0.8|>=9,<9.0.4|>=9.1,<9.1.3|>=10,<10.0.10|>=11,<11.0.3",
                 "blueimp/jquery-file-upload": "==6.4.4",
                 "bmarshall511/wordpress_zero_spam": "<5.2.13",
@@ -4785,7 +4839,7 @@
                 "lightsaml/lightsaml": "<1.3.5",
                 "limesurvey/limesurvey": "<6.5.12",
                 "livehelperchat/livehelperchat": "<=3.91",
-                "livewire/livewire": "<2.12.7|>=3.0.0.0-beta1,<3.5.2",
+                "livewire/livewire": "<2.12.7|>=3.0.0.0-beta1,<3.6.4",
                 "livewire/volt": "<1.7",
                 "lms/routes": "<2.1.1",
                 "localizationteam/l10nmgr": "<7.4|>=8,<8.7|>=9,<9.2",
@@ -5329,7 +5383,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-11T23:05:27+00:00"
+            "time": "2025-07-17T21:05:33+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/rector.php
+++ b/rector.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 use EliasHaeussler\RectorConfig\Config\Config;
 use Rector\Config\RectorConfig;
 use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;

--- a/src/Capability/ValidateTranslationCommandProvider.php
+++ b/src/Capability/ValidateTranslationCommandProvider.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Capability;
 
 use Composer\Plugin\Capability\CommandProvider;

--- a/src/Command/ValidateTranslationCommand.php
+++ b/src/Command/ValidateTranslationCommand.php
@@ -2,9 +2,29 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Command;
 
 use Composer\Command\BaseCommand;
+use JsonException;
 use MoveElevator\ComposerTranslationValidator\Config\ConfigReader;
 use MoveElevator\ComposerTranslationValidator\Config\TranslationValidatorConfig;
 use MoveElevator\ComposerTranslationValidator\FileDetector\Collector;
@@ -17,6 +37,7 @@ use MoveElevator\ComposerTranslationValidator\Validator\ResultType;
 use MoveElevator\ComposerTranslationValidator\Validator\ValidatorInterface;
 use MoveElevator\ComposerTranslationValidator\Validator\ValidatorRegistry;
 use Psr\Log\LoggerInterface;
+use ReflectionException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -45,50 +66,50 @@ class ValidateTranslationCommand extends BaseCommand
             ->addArgument(
                 'path',
                 InputArgument::IS_ARRAY | InputArgument::REQUIRED,
-                'Paths to the folders containing translation files'
+                'Paths to the folders containing translation files',
             )
             ->addOption(
                 'dry-run',
                 null,
                 InputOption::VALUE_NONE,
-                'Run the command in dry-run mode without throwing errors'
+                'Run the command in dry-run mode without throwing errors',
             )
             ->addOption(
                 'strict',
                 null,
                 InputOption::VALUE_NONE,
-                'Fail on warnings as errors'
+                'Fail on warnings as errors',
             )
             ->addOption(
                 'format',
                 'f',
                 InputOption::VALUE_OPTIONAL,
                 'Output format: cli or json',
-                FormatType::CLI->value
+                FormatType::CLI->value,
             )
             ->addOption(
                 'only',
                 'o',
                 InputOption::VALUE_OPTIONAL,
-                'The specific validators to use (FQCN), comma-separated'
+                'The specific validators to use (FQCN), comma-separated',
             )
             ->addOption(
                 'skip',
                 's',
                 InputOption::VALUE_OPTIONAL,
-                'Skip specific validators (FQCN), comma-separated'
+                'Skip specific validators (FQCN), comma-separated',
             )
             ->addOption(
                 'config',
                 'c',
                 InputOption::VALUE_OPTIONAL,
-                'Path to the configuration file'
+                'Path to the configuration file',
             )
             ->addOption(
                 'recursive',
                 'r',
                 InputOption::VALUE_NONE,
-                'Search for translation files recursively in subdirectories'
+                'Search for translation files recursively in subdirectories',
             )
             ->setHelp(
                 <<<HELP
@@ -142,7 +163,7 @@ HELP
     }
 
     /**
-     * @throws \ReflectionException|\JsonException
+     * @throws ReflectionException|JsonException
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
@@ -167,7 +188,7 @@ HELP
             $paths,
             $fileDetector,
             $excludePatterns,
-            $recursive
+            $recursive,
         );
         if (empty($allFiles)) {
             $this->io->warning('No files found in the specified directories.');
@@ -196,7 +217,7 @@ HELP
             $format,
             $validationResult,
             $this->dryRun,
-            $this->strict
+            $this->strict,
         ))->summarize();
     }
 
@@ -240,7 +261,7 @@ HELP
             static fn ($path) => str_starts_with((string) $path, '/')
                 ? $path
                 : getcwd().'/'.$path,
-            $paths
+            $paths,
         );
     }
 
@@ -253,7 +274,7 @@ HELP
             DetectorInterface::class,
             $this->logger,
             'file detector',
-            $fileDetectorClass
+            $fileDetectorClass,
         );
 
         return $detector instanceof DetectorInterface ? $detector : null;
@@ -269,12 +290,12 @@ HELP
         $inputOnly = $this->validateClassInput(
             ValidatorInterface::class,
             'validator',
-            $input->getOption('only')
+            $input->getOption('only'),
         );
         $inputSkip = $this->validateClassInput(
             ValidatorInterface::class,
             'validator',
-            $input->getOption('skip')
+            $input->getOption('skip'),
         );
 
         $only = !empty($inputOnly) ? $inputOnly : $config->getOnly();
@@ -311,7 +332,7 @@ HELP
                 $interface,
                 $this->logger,
                 $type,
-                $name
+                $name,
             );
             /** @var class-string $validatedName */
             $validatedName = $name;

--- a/src/Config/ConfigFactory.php
+++ b/src/Config/ConfigFactory.php
@@ -2,19 +2,39 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Config;
+
+use JsonException;
 
 class ConfigFactory
 {
     public function __construct(
         private readonly ConfigValidator $validator = new ConfigValidator(),
-    ) {
-    }
+    ) {}
 
     /**
      * @param array<string, mixed> $data
      *
-     * @throws \JsonException
+     * @throws JsonException
      */
     public function createFromArray(array $data): TranslationValidatorConfig
     {

--- a/src/Config/ConfigFileReader.php
+++ b/src/Config/ConfigFileReader.php
@@ -2,30 +2,51 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Config;
 
+use InvalidArgumentException;
+use JsonException;
+use RuntimeException;
 use Symfony\Component\Yaml\Yaml;
 
 class ConfigFileReader
 {
     public function __construct(
         private readonly ConfigFactory $factory = new ConfigFactory(),
-    ) {
-    }
+    ) {}
 
     /**
      * @return array<string, mixed>
      *
-     * @throws \JsonException
+     * @throws JsonException
      */
     public function readFile(string $configPath): array
     {
         if (!file_exists($configPath)) {
-            throw new \InvalidArgumentException("Configuration file not found: {$configPath}");
+            throw new InvalidArgumentException("Configuration file not found: {$configPath}");
         }
 
         if (!is_readable($configPath)) {
-            throw new \RuntimeException("Configuration file is not readable: {$configPath}");
+            throw new RuntimeException("Configuration file is not readable: {$configPath}");
         }
 
         $extension = pathinfo($configPath, PATHINFO_EXTENSION);
@@ -34,12 +55,12 @@ class ConfigFileReader
             'php' => $this->readPhpConfigAsArray($configPath),
             'json' => $this->readJsonConfig($configPath),
             'yaml', 'yml' => $this->readYamlConfig($configPath),
-            default => throw new \InvalidArgumentException("Unsupported configuration file format: {$extension}"),
+            default => throw new InvalidArgumentException("Unsupported configuration file format: {$extension}"),
         };
     }
 
     /**
-     * @throws \JsonException
+     * @throws JsonException
      */
     public function readAsConfig(string $configPath): TranslationValidatorConfig
     {
@@ -66,12 +87,12 @@ class ConfigFileReader
     {
         $realPath = realpath($configPath);
         if (false === $realPath) {
-            throw new \RuntimeException("Invalid configuration file path: {$configPath}");
+            throw new RuntimeException("Invalid configuration file path: {$configPath}");
         }
         $config = require $realPath;
 
         if (!$config instanceof TranslationValidatorConfig) {
-            throw new \RuntimeException('PHP configuration file must return an instance of TranslationValidatorConfig');
+            throw new RuntimeException('PHP configuration file must return an instance of TranslationValidatorConfig');
         }
 
         return $config;
@@ -80,18 +101,18 @@ class ConfigFileReader
     /**
      * @return array<string, mixed>
      *
-     * @throws \JsonException
+     * @throws JsonException
      */
     private function readJsonConfig(string $configPath): array
     {
         $content = file_get_contents($configPath);
         if (false === $content) {
-            throw new \RuntimeException("Failed to read configuration file: {$configPath}");
+            throw new RuntimeException("Failed to read configuration file: {$configPath}");
         }
 
         $data = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
         if (!is_array($data)) {
-            throw new \RuntimeException("Invalid JSON configuration file: {$configPath}");
+            throw new RuntimeException("Invalid JSON configuration file: {$configPath}");
         }
 
         return $data;
@@ -104,7 +125,7 @@ class ConfigFileReader
     {
         $data = Yaml::parseFile($configPath);
         if (!is_array($data)) {
-            throw new \RuntimeException("Invalid YAML configuration file: {$configPath}");
+            throw new RuntimeException("Invalid YAML configuration file: {$configPath}");
         }
 
         return $data;

--- a/src/Config/ConfigReader.php
+++ b/src/Config/ConfigReader.php
@@ -2,7 +2,28 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Config;
+
+use JsonException;
 
 class ConfigReader
 {
@@ -15,11 +36,10 @@ class ConfigReader
 
     public function __construct(
         private readonly ConfigFileReader $fileReader = new ConfigFileReader(),
-    ) {
-    }
+    ) {}
 
     /**
-     * @throws \JsonException
+     * @throws JsonException
      */
     public function read(string $configPath): TranslationValidatorConfig
     {
@@ -45,7 +65,7 @@ class ConfigReader
     }
 
     /**
-     * @throws \JsonException
+     * @throws JsonException
      */
     public function readFromComposerJson(string $composerJsonPath): ?TranslationValidatorConfig
     {

--- a/src/Config/ConfigValidator.php
+++ b/src/Config/ConfigValidator.php
@@ -2,7 +2,28 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Config;
+
+use RuntimeException;
 
 class ConfigValidator
 {
@@ -12,50 +33,50 @@ class ConfigValidator
     public function validate(array $data): void
     {
         if (isset($data['paths']) && !is_array($data['paths'])) {
-            throw new \RuntimeException("Configuration 'paths' must be an array");
+            throw new RuntimeException("Configuration 'paths' must be an array");
         }
 
         if (isset($data['validators']) && !is_array($data['validators'])) {
-            throw new \RuntimeException("Configuration 'validators' must be an array");
+            throw new RuntimeException("Configuration 'validators' must be an array");
         }
 
         if (isset($data['file-detectors']) && !is_array($data['file-detectors'])) {
-            throw new \RuntimeException("Configuration 'file-detectors' must be an array");
+            throw new RuntimeException("Configuration 'file-detectors' must be an array");
         }
 
         if (isset($data['parsers']) && !is_array($data['parsers'])) {
-            throw new \RuntimeException("Configuration 'parsers' must be an array");
+            throw new RuntimeException("Configuration 'parsers' must be an array");
         }
 
         if (isset($data['only']) && !is_array($data['only'])) {
-            throw new \RuntimeException("Configuration 'only' must be an array");
+            throw new RuntimeException("Configuration 'only' must be an array");
         }
 
         if (isset($data['skip']) && !is_array($data['skip'])) {
-            throw new \RuntimeException("Configuration 'skip' must be an array");
+            throw new RuntimeException("Configuration 'skip' must be an array");
         }
 
         if (isset($data['exclude']) && !is_array($data['exclude'])) {
-            throw new \RuntimeException("Configuration 'exclude' must be an array");
+            throw new RuntimeException("Configuration 'exclude' must be an array");
         }
 
         if (isset($data['strict']) && !is_bool($data['strict'])) {
-            throw new \RuntimeException("Configuration 'strict' must be a boolean");
+            throw new RuntimeException("Configuration 'strict' must be a boolean");
         }
 
         if (isset($data['dry-run']) && !is_bool($data['dry-run'])) {
-            throw new \RuntimeException("Configuration 'dry-run' must be a boolean");
+            throw new RuntimeException("Configuration 'dry-run' must be a boolean");
         }
 
         if (isset($data['format'])) {
             if (!is_string($data['format'])) {
-                throw new \RuntimeException("Configuration 'format' must be a string");
+                throw new RuntimeException("Configuration 'format' must be a string");
             }
             $this->validateFormat($data['format']);
         }
 
         if (isset($data['verbose']) && !is_bool($data['verbose'])) {
-            throw new \RuntimeException("Configuration 'verbose' must be a boolean");
+            throw new RuntimeException("Configuration 'verbose' must be a boolean");
         }
     }
 
@@ -63,7 +84,7 @@ class ConfigValidator
     {
         $allowedFormats = ['cli', 'json', 'yaml', 'php'];
         if (!in_array($format, $allowedFormats, true)) {
-            throw new \RuntimeException("Invalid format '{$format}'. Allowed formats: ".implode(', ', $allowedFormats));
+            throw new RuntimeException("Invalid format '{$format}'. Allowed formats: ".implode(', ', $allowedFormats));
         }
     }
 }

--- a/src/Config/SchemaValidator.php
+++ b/src/Config/SchemaValidator.php
@@ -2,7 +2,29 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Config;
+
+use JsonException;
+use RuntimeException;
 
 class SchemaValidator
 {
@@ -11,7 +33,7 @@ class SchemaValidator
     /**
      * @param array<string, mixed> $data
      *
-     * @throws \JsonException
+     * @throws JsonException
      */
     public function validate(array $data): void
     {
@@ -31,27 +53,27 @@ class SchemaValidator
                 $errors[] = sprintf('[%s] %s', $error['property'], $error['message']);
             }
 
-            throw new \RuntimeException('Configuration validation failed:'.PHP_EOL.implode(PHP_EOL, $errors));
+            throw new RuntimeException('Configuration validation failed:'.PHP_EOL.implode(PHP_EOL, $errors));
         }
     }
 
     /**
-     * @throws \JsonException
+     * @throws JsonException
      */
     private function loadSchema(): object
     {
         if (!file_exists(self::SCHEMA_PATH) || !is_readable(self::SCHEMA_PATH) || !is_file(self::SCHEMA_PATH)) {
-            throw new \RuntimeException('JSON Schema file not found: '.self::SCHEMA_PATH);
+            throw new RuntimeException('JSON Schema file not found: '.self::SCHEMA_PATH);
         }
 
         $schemaContent = file_get_contents(self::SCHEMA_PATH);
         if (false === $schemaContent) {
-            throw new \RuntimeException('Failed to read JSON Schema file: '.self::SCHEMA_PATH);
+            throw new RuntimeException('Failed to read JSON Schema file: '.self::SCHEMA_PATH);
         }
 
         $schema = json_decode($schemaContent, false, 512, JSON_THROW_ON_ERROR);
         if (null === $schema) {
-            throw new \RuntimeException('Invalid JSON Schema file: '.self::SCHEMA_PATH);
+            throw new RuntimeException('Invalid JSON Schema file: '.self::SCHEMA_PATH);
         }
 
         return $schema;

--- a/src/Config/TranslationValidatorConfig.php
+++ b/src/Config/TranslationValidatorConfig.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Config;
 
 class TranslationValidatorConfig

--- a/src/FileDetector/Collector.php
+++ b/src/FileDetector/Collector.php
@@ -2,17 +2,38 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\FileDetector;
 
+use Exception;
 use MoveElevator\ComposerTranslationValidator\Parser\ParserRegistry;
 use Psr\Log\LoggerInterface;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use ReflectionException;
 use Symfony\Component\Filesystem\Filesystem;
 
 class Collector
 {
-    public function __construct(protected ?LoggerInterface $logger = null)
-    {
-    }
+    public function __construct(protected ?LoggerInterface $logger = null) {}
 
     /**
      * @param string[]      $paths
@@ -20,7 +41,7 @@ class Collector
      *
      * @return array<class-string, array<string, array<mixed>>>
      *
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function collectFiles(
         array $paths,
@@ -47,8 +68,8 @@ class Collector
                         $files,
                         static fn ($file) => !array_filter(
                             $excludePatterns,
-                            static fn ($pattern) => fnmatch($pattern, basename((string) $file))
-                        )
+                            static fn ($pattern) => fnmatch($pattern, basename((string) $file)),
+                        ),
                     );
                 }
 
@@ -96,8 +117,8 @@ class Collector
                 static fn ($file) => in_array(
                     pathinfo($file, PATHINFO_EXTENSION),
                     $supportedExtensions,
-                    true
-                )
+                    true,
+                ),
             );
         }
 
@@ -111,9 +132,9 @@ class Collector
         $files = [];
 
         try {
-            $iterator = new \RecursiveIteratorIterator(
-                new \RecursiveDirectoryIterator($normalizedPath, \RecursiveDirectoryIterator::SKIP_DOTS),
-                \RecursiveIteratorIterator::LEAVES_ONLY
+            $iterator = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator($normalizedPath, RecursiveDirectoryIterator::SKIP_DOTS),
+                RecursiveIteratorIterator::LEAVES_ONLY,
             );
 
             foreach ($iterator as $file) {
@@ -124,7 +145,7 @@ class Collector
                     $files[] = $filePath;
                 }
             }
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->logger?->error('Error during recursive file search: '.$e->getMessage());
 
             return [];

--- a/src/FileDetector/DetectorInterface.php
+++ b/src/FileDetector/DetectorInterface.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\FileDetector;
 
 interface DetectorInterface

--- a/src/FileDetector/DirectoryFileDetector.php
+++ b/src/FileDetector/DirectoryFileDetector.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\FileDetector;
 
 class DirectoryFileDetector implements DetectorInterface

--- a/src/FileDetector/FileDetectorRegistry.php
+++ b/src/FileDetector/FileDetectorRegistry.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\FileDetector;
 
 class FileDetectorRegistry

--- a/src/FileDetector/FileSet.php
+++ b/src/FileDetector/FileSet.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\FileDetector;
 
 class FileSet
@@ -14,8 +33,7 @@ class FileSet
         private readonly string $path,
         private readonly string $setKey,
         private readonly array $files,
-    ) {
-    }
+    ) {}
 
     public function getParser(): string
     {

--- a/src/FileDetector/PrefixFileDetector.php
+++ b/src/FileDetector/PrefixFileDetector.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\FileDetector;
 
 class PrefixFileDetector implements DetectorInterface

--- a/src/FileDetector/SuffixFileDetector.php
+++ b/src/FileDetector/SuffixFileDetector.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\FileDetector;
 
 class SuffixFileDetector implements DetectorInterface

--- a/src/Parser/AbstractParser.php
+++ b/src/Parser/AbstractParser.php
@@ -2,7 +2,29 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Parser;
+
+use InvalidArgumentException;
+use RuntimeException;
 
 abstract class AbstractParser
 {
@@ -11,19 +33,19 @@ abstract class AbstractParser
     public function __construct(protected string $filePath)
     {
         if (!file_exists($filePath)) {
-            throw new \InvalidArgumentException(sprintf('File "%s" does not exist.', $filePath));
+            throw new InvalidArgumentException(sprintf('File "%s" does not exist.', $filePath));
         }
 
         if (!is_readable($filePath)) {
-            throw new \RuntimeException(sprintf('File "%s" is not readable.', $filePath));
+            throw new RuntimeException(sprintf('File "%s" is not readable.', $filePath));
         }
 
         if (!in_array(
             pathinfo($filePath, PATHINFO_EXTENSION),
             static::getSupportedFileExtensions(),
-            true
+            true,
         )) {
-            throw new \InvalidArgumentException(sprintf('File "%s" is not a valid file.', $filePath));
+            throw new InvalidArgumentException(sprintf('File "%s" is not a valid file.', $filePath));
         }
 
         $this->fileName = basename($filePath);

--- a/src/Parser/JsonParser.php
+++ b/src/Parser/JsonParser.php
@@ -2,7 +2,29 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Parser;
+
+use JsonException;
+use RuntimeException;
 
 class JsonParser extends AbstractParser implements ParserInterface
 {
@@ -16,17 +38,17 @@ class JsonParser extends AbstractParser implements ParserInterface
         try {
             $content = file_get_contents($filePath);
             if (false === $content) {
-                throw new \RuntimeException("Failed to read file: {$filePath}");
+                throw new RuntimeException("Failed to read file: {$filePath}");
             }
 
             $decoded = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
             if (!is_array($decoded) || array_is_list($decoded)) {
-                throw new \RuntimeException("JSON file does not contain an object: {$filePath}");
+                throw new RuntimeException("JSON file does not contain an object: {$filePath}");
             }
 
             $this->json = $decoded;
-        } catch (\JsonException $e) {
-            throw new \RuntimeException(sprintf('Failed to parse JSON file "%s": %s', $filePath, $e->getMessage()), 0, $e);
+        } catch (JsonException $e) {
+            throw new RuntimeException(sprintf('Failed to parse JSON file "%s": %s', $filePath, $e->getMessage()), 0, $e);
         }
     }
 
@@ -91,7 +113,7 @@ class JsonParser extends AbstractParser implements ParserInterface
         if (preg_match(
             '/\.([a-z]{2})(?:[-_][A-Z]{2})?\./',
             $this->getFileName(),
-            $matches
+            $matches,
         )) {
             return $matches[1];
         }

--- a/src/Parser/ParserCache.php
+++ b/src/Parser/ParserCache.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Parser;
 
 class ParserCache

--- a/src/Parser/ParserInterface.php
+++ b/src/Parser/ParserInterface.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Parser;
 
 interface ParserInterface

--- a/src/Parser/ParserRegistry.php
+++ b/src/Parser/ParserRegistry.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Parser;
 
 use Psr\Log\LoggerInterface;
@@ -36,14 +55,14 @@ class ParserRegistry
             if (in_array(
                 $fileExtension,
                 $parserClass::getSupportedFileExtensions(),
-                true
+                true,
             )) {
                 return $parserClass;
             }
         }
 
         $logger?->warning(
-            sprintf('No parser found for file: %s', $filePath)
+            sprintf('No parser found for file: %s', $filePath),
         );
 
         return null;

--- a/src/Parser/PhpParser.php
+++ b/src/Parser/PhpParser.php
@@ -2,7 +2,29 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Parser;
+
+use RuntimeException;
+use Throwable;
 
 class PhpParser extends AbstractParser implements ParserInterface
 {
@@ -15,8 +37,8 @@ class PhpParser extends AbstractParser implements ParserInterface
 
         try {
             $this->loadTranslations();
-        } catch (\Throwable $e) {
-            throw new \RuntimeException(sprintf('Failed to parse PHP file "%s": %s', $filePath, $e->getMessage()), 0, $e);
+        } catch (Throwable $e) {
+            throw new RuntimeException(sprintf('Failed to parse PHP file "%s": %s', $filePath, $e->getMessage()), 0, $e);
         }
     }
 
@@ -110,7 +132,7 @@ class PhpParser extends AbstractParser implements ParserInterface
             ob_end_clean();
 
             if (!is_array($result)) {
-                throw new \RuntimeException('PHP translation file must return an array');
+                throw new RuntimeException('PHP translation file must return an array');
             }
 
             $this->translations = $result;

--- a/src/Parser/XliffParser.php
+++ b/src/Parser/XliffParser.php
@@ -2,17 +2,39 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Parser;
+
+use InvalidArgumentException;
+use SimpleXMLElement;
 
 class XliffParser extends AbstractParser implements ParserInterface
 {
-    private readonly \SimpleXMLElement|bool $xml;
+    private readonly SimpleXMLElement|bool $xml;
 
     /**
      * @param string $filePath Path to the XLIFF file
      *
-     * @throws \InvalidArgumentException If file cannot be parsed as
-     *                                   valid XML
+     * @throws InvalidArgumentException If file cannot be parsed as
+     *                                  valid XML
      */
     public function __construct(protected string $filePath)
     {
@@ -20,14 +42,14 @@ class XliffParser extends AbstractParser implements ParserInterface
 
         $xmlContent = file_get_contents($filePath);
         if (false === $xmlContent) {
-            throw new \InvalidArgumentException("Failed to read file: {$filePath}");
+            throw new InvalidArgumentException("Failed to read file: {$filePath}");
         }
 
         libxml_use_internal_errors(true);
         $this->xml = simplexml_load_string($xmlContent);
 
         if (false === $this->xml) {
-            throw new \InvalidArgumentException("Failed to parse XML content from file: {$filePath}");
+            throw new InvalidArgumentException("Failed to parse XML content from file: {$filePath}");
         }
         libxml_clear_errors();
     }
@@ -87,7 +109,7 @@ class XliffParser extends AbstractParser implements ParserInterface
         if (preg_match(
             '/^([a-z]{2})\./i',
             $this->getFileName(),
-            $matches
+            $matches,
         )) {
             $language = $matches[1];
         } else {

--- a/src/Parser/YamlParser.php
+++ b/src/Parser/YamlParser.php
@@ -2,8 +2,29 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Parser;
 
+use Exception;
+use RuntimeException;
 use Symfony\Component\Yaml\Yaml;
 
 class YamlParser extends AbstractParser implements ParserInterface
@@ -17,8 +38,8 @@ class YamlParser extends AbstractParser implements ParserInterface
 
         try {
             $this->yaml = Yaml::parseFile($filePath);
-        } catch (\Exception $e) {
-            throw new \RuntimeException(sprintf('Failed to parse YAML file "%s": %s', $filePath, $e->getMessage()), 0, $e);
+        } catch (Exception $e) {
+            throw new RuntimeException(sprintf('Failed to parse YAML file "%s": %s', $filePath, $e->getMessage()), 0, $e);
         }
     }
 
@@ -83,7 +104,7 @@ class YamlParser extends AbstractParser implements ParserInterface
         if (preg_match(
             '/\.(\w{2})\./',
             $this->getFileName(),
-            $matches
+            $matches,
         )) {
             return $matches[1];
         }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator;
 
 use Composer\Composer;
@@ -13,17 +32,11 @@ use MoveElevator\ComposerTranslationValidator\Capability\ValidateTranslationComm
 
 class Plugin implements PluginInterface, Capable
 {
-    public function activate(Composer $composer, IOInterface $io): void
-    {
-    }
+    public function activate(Composer $composer, IOInterface $io): void {}
 
-    public function deactivate(Composer $composer, IOInterface $io): void
-    {
-    }
+    public function deactivate(Composer $composer, IOInterface $io): void {}
 
-    public function uninstall(Composer $composer, IOInterface $io): void
-    {
-    }
+    public function uninstall(Composer $composer, IOInterface $io): void {}
 
     public function getCapabilities(): array
     {

--- a/src/Result/AbstractValidationResultRenderer.php
+++ b/src/Result/AbstractValidationResultRenderer.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Result;
 
 use MoveElevator\ComposerTranslationValidator\Validator\ResultType;
@@ -13,8 +32,7 @@ abstract class AbstractValidationResultRenderer implements ValidationResultRende
         protected readonly OutputInterface $output,
         protected readonly bool $dryRun = false,
         protected readonly bool $strict = false,
-    ) {
-    }
+    ) {}
 
     protected function generateMessage(ValidationResult $validationResult): string
     {

--- a/src/Result/FormatType.php
+++ b/src/Result/FormatType.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Result;
 
 enum FormatType: string

--- a/src/Result/Issue.php
+++ b/src/Result/Issue.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Result;
 
 class Issue
@@ -14,8 +33,7 @@ class Issue
         private readonly array $details,
         private readonly string $parser,
         private readonly string $validatorType,
-    ) {
-    }
+    ) {}
 
     public function getFile(): string
     {

--- a/src/Result/Output.php
+++ b/src/Result/Output.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Result;
 
 use Psr\Log\LoggerInterface;
@@ -18,8 +37,7 @@ class Output
         protected ValidationResult $validationResult,
         protected bool $dryRun = false,
         protected bool $strict = false,
-    ) {
-    }
+    ) {}
 
     /**
      * Summarizes validation results in the specified format.
@@ -33,7 +51,7 @@ class Output
             $this->output,
             $this->input,
             $this->dryRun,
-            $this->strict
+            $this->strict,
         );
 
         return $renderer->render($this->validationResult);

--- a/src/Result/ValidationResult.php
+++ b/src/Result/ValidationResult.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Result;
 
 use MoveElevator\ComposerTranslationValidator\FileDetector\FileSet;
@@ -19,8 +38,7 @@ class ValidationResult
         private readonly ResultType $overallResult,
         private readonly array $validatorFileSetPairs = [],
         private readonly ?ValidationStatistics $statistics = null,
-    ) {
-    }
+    ) {}
 
     public function hasIssues(): bool
     {

--- a/src/Result/ValidationResultCliRenderer.php
+++ b/src/Result/ValidationResultCliRenderer.php
@@ -2,14 +2,35 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Result;
 
 use MoveElevator\ComposerTranslationValidator\Utility\PathUtility;
 use MoveElevator\ComposerTranslationValidator\Validator\ResultType;
 use MoveElevator\ComposerTranslationValidator\Validator\ValidatorInterface;
+use ReflectionClass;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Throwable;
 
 class ValidationResultCliRenderer extends AbstractValidationResultRenderer
 {
@@ -211,7 +232,7 @@ class ValidationResultCliRenderer extends AbstractValidationResultRenderer
                 return 1;
             }
             /** @var class-string $validatorClass */
-            $reflection = new \ReflectionClass($validatorClass);
+            $reflection = new ReflectionClass($validatorClass);
             if ($reflection->isInstantiable()) {
                 $validator = $reflection->newInstance();
                 if ($validator instanceof ValidatorInterface) {
@@ -220,7 +241,7 @@ class ValidationResultCliRenderer extends AbstractValidationResultRenderer
                     return ResultType::ERROR === $resultType ? 1 : 2;
                 }
             }
-        } catch (\Throwable) {
+        } catch (Throwable) {
         }
 
         return 1;

--- a/src/Result/ValidationResultJsonRenderer.php
+++ b/src/Result/ValidationResultJsonRenderer.php
@@ -2,12 +2,33 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Result;
+
+use JsonException;
 
 class ValidationResultJsonRenderer extends AbstractValidationResultRenderer
 {
     /**
-     * @throws \JsonException
+     * @throws JsonException
      */
     public function render(ValidationResult $validationResult): int
     {
@@ -21,7 +42,7 @@ class ValidationResultJsonRenderer extends AbstractValidationResultRenderer
         ];
 
         $this->output->writeln(
-            json_encode($result, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)
+            json_encode($result, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE),
         );
 
         return $exitCode;

--- a/src/Result/ValidationResultRendererFactory.php
+++ b/src/Result/ValidationResultRendererFactory.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Result;
 
 use Symfony\Component\Console\Input\InputInterface;

--- a/src/Result/ValidationResultRendererInterface.php
+++ b/src/Result/ValidationResultRendererInterface.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Result;
 
 interface ValidationResultRendererInterface

--- a/src/Result/ValidationRun.php
+++ b/src/Result/ValidationRun.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Result;
 
 use MoveElevator\ComposerTranslationValidator\FileDetector\FileSet;
@@ -9,13 +28,13 @@ use MoveElevator\ComposerTranslationValidator\Parser\ParserCache;
 use MoveElevator\ComposerTranslationValidator\Validator\ResultType;
 use MoveElevator\ComposerTranslationValidator\Validator\ValidatorInterface;
 use Psr\Log\LoggerInterface;
+use Throwable;
 
 class ValidationRun
 {
     public function __construct(
         private readonly LoggerInterface $logger,
-    ) {
-    }
+    ) {}
 
     /**
      * @param array<FileSet>                          $fileSets
@@ -61,7 +80,7 @@ class ValidationRun
             $filesChecked,
             $keysChecked,
             $validatorsRun,
-            $parsersCached
+            $parsersCached,
         );
 
         $validationResult = new ValidationResult($validatorInstances, $overallResult, $validatorFileSetPairs, $statistics);
@@ -110,7 +129,7 @@ class ValidationRun
                     if (is_array($keys)) {
                         $keysChecked += count($keys);
                     }
-                } catch (\Throwable) {
+                } catch (Throwable) {
                     // Skip files that can't be parsed
                 }
             }

--- a/src/Result/ValidationStatistics.php
+++ b/src/Result/ValidationStatistics.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Result;
 
 class ValidationStatistics
@@ -12,8 +31,7 @@ class ValidationStatistics
         private readonly int $keysChecked,
         private readonly int $validatorsRun,
         private readonly int $parsersCached = 0,
-    ) {
-    }
+    ) {}
 
     public function getExecutionTime(): float
     {

--- a/src/Utility/ClassUtility.php
+++ b/src/Utility/ClassUtility.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Utility;
 
 use Psr\Log\LoggerInterface;
@@ -24,8 +43,8 @@ class ClassUtility
                     'The %s class "%s" must implement %s.',
                     $type,
                     $className,
-                    $interface
-                )
+                    $interface,
+                ),
             );
 
             return null;
@@ -45,7 +64,7 @@ class ClassUtility
 
         if (!class_exists($class)) {
             $logger->error(
-                sprintf('The class "%s" does not exist.', $class)
+                sprintf('The class "%s" does not exist.', $class),
             );
 
             return false;
@@ -56,8 +75,8 @@ class ClassUtility
                 sprintf(
                     'The class "%s" must implement %s.',
                     $class,
-                    $interface
-                )
+                    $interface,
+                ),
             );
 
             return false;

--- a/src/Utility/OutputUtility.php
+++ b/src/Utility/OutputUtility.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Utility;
 
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/Utility/PathUtility.php
+++ b/src/Utility/PathUtility.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Utility;
 
 class PathUtility

--- a/src/Validator/AbstractValidator.php
+++ b/src/Validator/AbstractValidator.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Validator;
 
 use MoveElevator\ComposerTranslationValidator\FileDetector\FileSet;
@@ -17,9 +36,7 @@ abstract class AbstractValidator
     /** @var array<Issue> */
     protected array $issues = [];
 
-    public function __construct(protected ?LoggerInterface $logger = null)
-    {
-    }
+    public function __construct(protected ?LoggerInterface $logger = null) {}
 
     /**
      * @param string[]                           $files
@@ -36,8 +53,8 @@ abstract class AbstractValidator
         $this->logger->debug(
             sprintf(
                 '> Checking for <options=bold,underscore>%s</> ...',
-                $name
-            )
+                $name,
+            ),
         );
 
         foreach ($files as $filePath) {
@@ -45,8 +62,8 @@ abstract class AbstractValidator
                 $filePath,
                 $parserClass ?: ParserRegistry::resolveParserClass(
                     $filePath,
-                    $this->logger
-                )
+                    $this->logger,
+                ),
             );
             /* @var ParserInterface $file */
 
@@ -56,8 +73,8 @@ abstract class AbstractValidator
                         'The file <fg=cyan>%s</> could not be parsed by the '
                         .'validator <fg=red>%s</>.',
                         $filePath,
-                        static::class
-                    )
+                        static::class,
+                    ),
                 );
                 continue;
             }
@@ -67,8 +84,8 @@ abstract class AbstractValidator
                     sprintf(
                         'The file <fg=cyan>%s</> is not supported by the validator <fg=red>%s</>.',
                         $file->getFileName(),
-                        static::class
-                    )
+                        static::class,
+                    ),
                 );
                 continue;
             }
@@ -78,7 +95,7 @@ abstract class AbstractValidator
                 .$file->getFileDirectory()
                 .'</><fg=cyan>'
                 .$file->getFileName()
-                .'</> ...'
+                .'</> ...',
             );
 
             $validationResult = $this->processFile($file);
@@ -90,7 +107,7 @@ abstract class AbstractValidator
                 $file->getFileName(),
                 $validationResult,
                 $file::class,
-                $name
+                $name,
             ));
         }
 

--- a/src/Validator/DuplicateKeysValidator.php
+++ b/src/Validator/DuplicateKeysValidator.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Validator;
 
 use MoveElevator\ComposerTranslationValidator\Parser\JsonParser;
@@ -22,7 +41,7 @@ class DuplicateKeysValidator extends AbstractValidator implements ValidatorInter
 
         if (!$keys) {
             $this->logger?->error(
-                'The source file '.$file->getFileName().' is not valid.'
+                'The source file '.$file->getFileName().' is not valid.',
             );
 
             return [];
@@ -30,7 +49,7 @@ class DuplicateKeysValidator extends AbstractValidator implements ValidatorInter
 
         $duplicateKeys = array_filter(
             array_count_values($keys),
-            static fn ($count) => $count > 1
+            static fn ($count) => $count > 1,
         );
         if (!empty($duplicateKeys)) {
             return $duplicateKeys;

--- a/src/Validator/DuplicateValuesValidator.php
+++ b/src/Validator/DuplicateValuesValidator.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Validator;
 
 use MoveElevator\ComposerTranslationValidator\Parser\JsonParser;
@@ -54,7 +73,7 @@ class DuplicateValuesValidator extends AbstractValidator implements ValidatorInt
                     $file,
                     $duplicates,
                     '',
-                    $this->getShortName()
+                    $this->getShortName(),
                 ));
             }
         }

--- a/src/Validator/EmptyValuesValidator.php
+++ b/src/Validator/EmptyValuesValidator.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Validator;
 
 use MoveElevator\ComposerTranslationValidator\Parser\JsonParser;
@@ -22,7 +41,7 @@ class EmptyValuesValidator extends AbstractValidator implements ValidatorInterfa
 
         if (null === $keys) {
             $this->logger?->error(
-                'The source file '.$file->getFileName().' is not valid.'
+                'The source file '.$file->getFileName().' is not valid.',
             );
 
             return [];

--- a/src/Validator/EncodingValidator.php
+++ b/src/Validator/EncodingValidator.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Validator;
 
 use MoveElevator\ComposerTranslationValidator\Parser\JsonParser;
@@ -10,6 +29,7 @@ use MoveElevator\ComposerTranslationValidator\Parser\PhpParser;
 use MoveElevator\ComposerTranslationValidator\Parser\XliffParser;
 use MoveElevator\ComposerTranslationValidator\Parser\YamlParser;
 use MoveElevator\ComposerTranslationValidator\Result\Issue;
+use Normalizer;
 
 class EncodingValidator extends AbstractValidator implements ValidatorInterface
 {
@@ -25,7 +45,7 @@ class EncodingValidator extends AbstractValidator implements ValidatorInterface
         $content = file_get_contents($filePath);
         if (false === $content) {
             $this->logger?->error(
-                'Could not read file content: '.$file->getFileName()
+                'Could not read file content: '.$file->getFileName(),
             );
 
             return [];
@@ -55,7 +75,7 @@ class EncodingValidator extends AbstractValidator implements ValidatorInterface
         if (!empty($invisibleChars)) {
             $issues['invisible_chars'] = sprintf(
                 'File contains invisible characters: %s',
-                implode(', ', array_unique($invisibleChars))
+                implode(', ', array_unique($invisibleChars)),
             );
         }
 
@@ -161,7 +181,7 @@ class EncodingValidator extends AbstractValidator implements ValidatorInterface
             return false;
         }
 
-        $normalized = \Normalizer::normalize($content, \Normalizer::FORM_C);
+        $normalized = Normalizer::normalize($content, Normalizer::FORM_C);
 
         return false !== $normalized && $content !== $normalized;
     }

--- a/src/Validator/MismatchValidator.php
+++ b/src/Validator/MismatchValidator.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Validator;
 
 use MoveElevator\ComposerTranslationValidator\FileDetector\FileSet;
@@ -68,7 +87,7 @@ class MismatchValidator extends AbstractValidator implements ValidatorInterface
                     '',
                     $result,
                     '',
-                    $this->getShortName()
+                    $this->getShortName(),
                 ));
             }
         }
@@ -126,7 +145,7 @@ class MismatchValidator extends AbstractValidator implements ValidatorInterface
                         $filePath,
                         $details,
                         $issue->getParser(),
-                        $issue->getValidatorType()
+                        $issue->getValidatorType(),
                     );
 
                     if (!isset($distribution[$filePath])) {
@@ -206,7 +225,7 @@ class MismatchValidator extends AbstractValidator implements ValidatorInterface
             ->setRows($rows)
             ->setStyle(
                 (new TableStyle())
-                    ->setCellHeaderFormat('%s')
+                    ->setCellHeaderFormat('%s'),
             )
             ->render();
     }

--- a/src/Validator/PlaceholderConsistencyValidator.php
+++ b/src/Validator/PlaceholderConsistencyValidator.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Validator;
 
 use MoveElevator\ComposerTranslationValidator\FileDetector\FileSet;
@@ -26,7 +45,7 @@ class PlaceholderConsistencyValidator extends AbstractValidator implements Valid
 
         if (null === $keys) {
             $this->logger?->error(
-                'The source file '.$file->getFileName().' is not valid.'
+                'The source file '.$file->getFileName().' is not valid.',
             );
 
             return [];
@@ -64,7 +83,7 @@ class PlaceholderConsistencyValidator extends AbstractValidator implements Valid
                     '',
                     $result,
                     '',
-                    $this->getShortName()
+                    $this->getShortName(),
                 ));
             }
         }
@@ -199,7 +218,7 @@ class PlaceholderConsistencyValidator extends AbstractValidator implements Valid
                         $filePath,
                         $details,
                         $issue->getParser(),
-                        $issue->getValidatorType()
+                        $issue->getValidatorType(),
                     );
 
                     $distribution[$filePath] ??= [];
@@ -264,7 +283,7 @@ class PlaceholderConsistencyValidator extends AbstractValidator implements Valid
             ->setRows($rows)
             ->setStyle(
                 (new TableStyle())
-                    ->setCellHeaderFormat('%s')
+                    ->setCellHeaderFormat('%s'),
             )
             ->render();
     }

--- a/src/Validator/ResultType.php
+++ b/src/Validator/ResultType.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Validator;
 
 use Symfony\Component\Console\Command\Command;

--- a/src/Validator/ValidatorInterface.php
+++ b/src/Validator/ValidatorInterface.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Validator;
 
 use MoveElevator\ComposerTranslationValidator\FileDetector\FileSet;

--- a/src/Validator/ValidatorRegistry.php
+++ b/src/Validator/ValidatorRegistry.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Validator;
 
 class ValidatorRegistry

--- a/src/Validator/XliffSchemaValidator.php
+++ b/src/Validator/XliffSchemaValidator.php
@@ -2,8 +2,28 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Validator;
 
+use Exception;
 use MoveElevator\ComposerTranslationValidator\Parser\ParserInterface;
 use MoveElevator\ComposerTranslationValidator\Parser\XliffParser;
 use MoveElevator\ComposerTranslationValidator\Result\Issue;
@@ -33,7 +53,7 @@ class XliffSchemaValidator extends AbstractValidator implements ValidatorInterfa
             }
             $dom = XmlUtils::parse($fileContent);
             $errors = XliffUtils::validateSchema($dom);
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             if (str_contains($e->getMessage(), 'No support implemented for loading XLIFF version')) {
                 $this->logger?->notice(sprintf('Skipping %s: %s', $this->getShortName(), $e->getMessage()));
             } else {

--- a/tests/Build/console-application.php
+++ b/tests/Build/console-application.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 use MoveElevator\ComposerTranslationValidator\Command\ValidateTranslationCommand;
 use Symfony\Component\Console;
 

--- a/tests/src/Capability/ValidateTranslationCommandProviderTest.php
+++ b/tests/src/Capability/ValidateTranslationCommandProviderTest.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Capability;
 
 use MoveElevator\ComposerTranslationValidator\Capability\ValidateTranslationCommandProvider;

--- a/tests/src/Command/ValidateTranslationCommandConfigTestSimple.php
+++ b/tests/src/Command/ValidateTranslationCommandConfigTestSimple.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Command;
 
 use MoveElevator\ComposerTranslationValidator\Command\ValidateTranslationCommand;

--- a/tests/src/Command/ValidateTranslationCommandTest.php
+++ b/tests/src/Command/ValidateTranslationCommandTest.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Command;
 
 use Composer\Console\Application;
@@ -10,6 +29,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
+use Throwable;
 
 #[CoversClass(ValidateTranslationCommand::class)]
 class ValidateTranslationCommandTest extends TestCase
@@ -78,10 +98,10 @@ class ValidateTranslationCommandTest extends TestCase
                 '--only' => 'Invalid\\Validator\\Class',
             ]);
             $this->fail('Expected exception was not thrown.');
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             $this->assertStringContainsString(
                 'Class "Invalid\Validator\Class" not found',
-                $e->getMessage()
+                $e->getMessage(),
             );
         }
     }

--- a/tests/src/Config/ConfigFactoryTest.php
+++ b/tests/src/Config/ConfigFactoryTest.php
@@ -2,10 +2,30 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Config;
 
 use MoveElevator\ComposerTranslationValidator\Config\ConfigFactory;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 final class ConfigFactoryTest extends TestCase
 {
@@ -84,7 +104,7 @@ final class ConfigFactoryTest extends TestCase
 
     public function testCreateFromArrayValidatesData(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Configuration validation failed');
 
         $this->factory->createFromArray(['paths' => 'invalid']);
@@ -92,7 +112,7 @@ final class ConfigFactoryTest extends TestCase
 
     public function testCreateFromArrayValidatesFormatValue(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Configuration validation failed');
 
         $this->factory->createFromArray(['format' => 'invalid']);

--- a/tests/src/Config/ConfigFileReaderTest.php
+++ b/tests/src/Config/ConfigFileReaderTest.php
@@ -2,10 +2,33 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Config;
 
+use Exception;
+use InvalidArgumentException;
+use JsonException;
 use MoveElevator\ComposerTranslationValidator\Config\ConfigFileReader;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 final class ConfigFileReaderTest extends TestCase
 {
@@ -126,7 +149,7 @@ return $config;
 
     public function testReadFileNotFound(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Configuration file not found');
 
         $this->reader->readFile('/non/existent/file.json');
@@ -138,7 +161,7 @@ return $config;
         file_put_contents($configPath, '{}');
         chmod($configPath, 0000);
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Configuration file is not readable');
 
         try {
@@ -153,7 +176,7 @@ return $config;
         $configPath = $this->tempDir.'/config.txt';
         file_put_contents($configPath, 'content');
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unsupported configuration file format: txt');
 
         $this->reader->readFile($configPath);
@@ -164,7 +187,7 @@ return $config;
         $configPath = $this->tempDir.'/config.json';
         file_put_contents($configPath, 'invalid json');
 
-        $this->expectException(\JsonException::class);
+        $this->expectException(JsonException::class);
 
         $this->reader->readFile($configPath);
     }
@@ -174,7 +197,7 @@ return $config;
         $configPath = $this->tempDir.'/config.yaml';
         file_put_contents($configPath, "invalid:\n  - yaml\n  content:");
 
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
 
         $this->reader->readFile($configPath);
     }
@@ -184,7 +207,7 @@ return $config;
         $configPath = $this->tempDir.'/config.php';
         file_put_contents($configPath, '<?php return "invalid";');
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('PHP configuration file must return an instance of TranslationValidatorConfig');
 
         $this->reader->readAsConfig($configPath);
@@ -200,7 +223,7 @@ return $config;
         symlink($configPath, $brokenLink);
         unlink($configPath); // Break the symlink
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Invalid configuration file path');
 
         $this->reader->readAsConfig($brokenLink);
@@ -211,7 +234,7 @@ return $config;
         $configPath = $this->tempDir.'/config.json';
         file_put_contents($configPath, '"string-content"');
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Invalid JSON configuration file');
 
         $this->reader->readFile($configPath);
@@ -222,7 +245,7 @@ return $config;
         $configPath = $this->tempDir.'/config.yaml';
         file_put_contents($configPath, '"string-content"');
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Invalid YAML configuration file');
 
         $this->reader->readFile($configPath);

--- a/tests/src/Config/ConfigReaderTest.php
+++ b/tests/src/Config/ConfigReaderTest.php
@@ -2,12 +2,34 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Config;
 
+use InvalidArgumentException;
+use JsonException;
 use MoveElevator\ComposerTranslationValidator\Config\ConfigReader;
 use MoveElevator\ComposerTranslationValidator\Config\TranslationValidatorConfig;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 #[CoversClass(ConfigReader::class)]
 class ConfigReaderTest extends TestCase
@@ -23,7 +45,7 @@ class ConfigReaderTest extends TestCase
 
     public function testReadNonExistentFile(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Configuration file not found:');
 
         $this->configReader->read('/non/existent/file.json');
@@ -34,7 +56,7 @@ class ConfigReaderTest extends TestCase
         $configFile = $this->fixturesDir.'/unsupported.txt';
         file_put_contents($configFile, 'some content');
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unsupported configuration file format: txt');
 
         $this->configReader->read($configFile);
@@ -57,7 +79,7 @@ class ConfigReaderTest extends TestCase
     {
         $configFile = $this->fixturesDir.'/invalid.php';
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('PHP configuration file must return an instance of TranslationValidatorConfig');
 
         $this->configReader->read($configFile);
@@ -78,7 +100,7 @@ class ConfigReaderTest extends TestCase
     {
         $configFile = $this->fixturesDir.'/invalid.json';
 
-        $this->expectException(\JsonException::class);
+        $this->expectException(JsonException::class);
         $this->expectExceptionMessage('Syntax error');
 
         $this->configReader->read($configFile);
@@ -208,7 +230,7 @@ class ConfigReaderTest extends TestCase
     {
         $configFile = $this->fixturesDir.'/invalid-paths.json';
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Configuration validation failed:');
 
         $this->configReader->read($configFile);
@@ -218,7 +240,7 @@ class ConfigReaderTest extends TestCase
     {
         $configFile = $this->fixturesDir.'/invalid-format.json';
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Configuration validation failed:');
 
         $this->configReader->read($configFile);
@@ -254,7 +276,7 @@ class ConfigReaderTest extends TestCase
         file_put_contents($configFile, json_encode(['paths' => ['test']]));
         chmod($configFile, 0000);
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Configuration file is not readable:');
 
         try {
@@ -273,7 +295,7 @@ class ConfigReaderTest extends TestCase
         $composerJson = $tempDir.'/composer.json';
         file_put_contents($composerJson, 'invalid json');
 
-        $this->expectException(\JsonException::class);
+        $this->expectException(JsonException::class);
         $this->expectExceptionMessage('Syntax error');
 
         try {
@@ -355,7 +377,7 @@ class ConfigReaderTest extends TestCase
         $configFile = $this->fixturesDir.'/scalar.yaml';
         file_put_contents($configFile, 'scalar-value');
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Invalid YAML configuration file:');
 
         try {
@@ -370,7 +392,7 @@ class ConfigReaderTest extends TestCase
         $configFile = $this->fixturesDir.'/invalid-validators.json';
         file_put_contents($configFile, json_encode(['validators' => 'not-array']));
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Configuration validation failed:');
 
         try {
@@ -385,7 +407,7 @@ class ConfigReaderTest extends TestCase
         $configFile = $this->fixturesDir.'/invalid-parsers.json';
         file_put_contents($configFile, json_encode(['parsers' => 'not-array']));
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Configuration validation failed:');
 
         try {
@@ -400,7 +422,7 @@ class ConfigReaderTest extends TestCase
         $configFile = $this->fixturesDir.'/invalid-strict.json';
         file_put_contents($configFile, json_encode(['strict' => 'not-bool']));
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Configuration validation failed:');
 
         try {
@@ -415,7 +437,7 @@ class ConfigReaderTest extends TestCase
         $configFile = $this->fixturesDir.'/invalid-dry-run.json';
         file_put_contents($configFile, json_encode(['dry-run' => 'not-bool']));
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Configuration validation failed:');
 
         try {
@@ -430,7 +452,7 @@ class ConfigReaderTest extends TestCase
         $configFile = $this->fixturesDir.'/invalid-verbose.json';
         file_put_contents($configFile, json_encode(['verbose' => 'not-bool']));
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Configuration validation failed:');
 
         try {
@@ -445,7 +467,7 @@ class ConfigReaderTest extends TestCase
         $configFile = $this->fixturesDir.'/invalid-format-type.json';
         file_put_contents($configFile, json_encode(['format' => 123]));
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Configuration validation failed:');
 
         try {

--- a/tests/src/Config/ConfigValidatorTest.php
+++ b/tests/src/Config/ConfigValidatorTest.php
@@ -2,10 +2,30 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Config;
 
 use MoveElevator\ComposerTranslationValidator\Config\ConfigValidator;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 final class ConfigValidatorTest extends TestCase
 {
@@ -38,7 +58,7 @@ final class ConfigValidatorTest extends TestCase
 
     public function testValidateInvalidPathsType(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage("Configuration 'paths' must be an array");
 
         $this->validator->validate(['paths' => 'invalid']);
@@ -46,7 +66,7 @@ final class ConfigValidatorTest extends TestCase
 
     public function testValidateInvalidValidatorsType(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage("Configuration 'validators' must be an array");
 
         $this->validator->validate(['validators' => 'invalid']);
@@ -54,7 +74,7 @@ final class ConfigValidatorTest extends TestCase
 
     public function testValidateInvalidFileDetectorsType(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage("Configuration 'file-detectors' must be an array");
 
         $this->validator->validate(['file-detectors' => 'invalid']);
@@ -62,7 +82,7 @@ final class ConfigValidatorTest extends TestCase
 
     public function testValidateInvalidParsersType(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage("Configuration 'parsers' must be an array");
 
         $this->validator->validate(['parsers' => 'invalid']);
@@ -70,7 +90,7 @@ final class ConfigValidatorTest extends TestCase
 
     public function testValidateInvalidOnlyType(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage("Configuration 'only' must be an array");
 
         $this->validator->validate(['only' => 'invalid']);
@@ -78,7 +98,7 @@ final class ConfigValidatorTest extends TestCase
 
     public function testValidateInvalidSkipType(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage("Configuration 'skip' must be an array");
 
         $this->validator->validate(['skip' => 'invalid']);
@@ -86,7 +106,7 @@ final class ConfigValidatorTest extends TestCase
 
     public function testValidateInvalidExcludeType(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage("Configuration 'exclude' must be an array");
 
         $this->validator->validate(['exclude' => 'invalid']);
@@ -94,7 +114,7 @@ final class ConfigValidatorTest extends TestCase
 
     public function testValidateInvalidStrictType(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage("Configuration 'strict' must be a boolean");
 
         $this->validator->validate(['strict' => 'invalid']);
@@ -102,7 +122,7 @@ final class ConfigValidatorTest extends TestCase
 
     public function testValidateInvalidDryRunType(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage("Configuration 'dry-run' must be a boolean");
 
         $this->validator->validate(['dry-run' => 'invalid']);
@@ -110,7 +130,7 @@ final class ConfigValidatorTest extends TestCase
 
     public function testValidateInvalidFormatType(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage("Configuration 'format' must be a string");
 
         $this->validator->validate(['format' => 123]);
@@ -118,7 +138,7 @@ final class ConfigValidatorTest extends TestCase
 
     public function testValidateInvalidFormatValue(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage("Invalid format 'invalid'. Allowed formats: cli, json, yaml, php");
 
         $this->validator->validate(['format' => 'invalid']);
@@ -126,7 +146,7 @@ final class ConfigValidatorTest extends TestCase
 
     public function testValidateInvalidVerboseType(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage("Configuration 'verbose' must be a boolean");
 
         $this->validator->validate(['verbose' => 'invalid']);

--- a/tests/src/Config/SchemaValidatorTest.php
+++ b/tests/src/Config/SchemaValidatorTest.php
@@ -2,11 +2,33 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Config;
 
+use JsonException;
 use MoveElevator\ComposerTranslationValidator\Config\SchemaValidator;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use RuntimeException;
 
 #[CoversClass(SchemaValidator::class)]
 class SchemaValidatorTest extends TestCase
@@ -65,7 +87,7 @@ class SchemaValidatorTest extends TestCase
     {
         $emptyData = [];
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Configuration validation failed:');
 
         $this->schemaValidator->validate($emptyData);
@@ -78,7 +100,7 @@ class SchemaValidatorTest extends TestCase
             'format' => 'invalid-format', // Invalid enum value
         ];
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Configuration validation failed:');
 
         $this->schemaValidator->validate($invalidData);
@@ -87,7 +109,7 @@ class SchemaValidatorTest extends TestCase
     public function testLoadSchemaFileNotFoundThrowsException(): void
     {
         // Create a temporary SchemaValidator with a non-existent schema path
-        $reflection = new \ReflectionClass(SchemaValidator::class);
+        $reflection = new ReflectionClass(SchemaValidator::class);
         $schemaPathProperty = $reflection->getConstant('SCHEMA_PATH');
 
         // Backup the original schema file and rename it temporarily
@@ -97,7 +119,7 @@ class SchemaValidatorTest extends TestCase
         }
 
         try {
-            $this->expectException(\RuntimeException::class);
+            $this->expectException(RuntimeException::class);
             $this->expectExceptionMessage('JSON Schema file not found:');
 
             $this->schemaValidator->validate(['paths' => ['test']]);
@@ -111,7 +133,7 @@ class SchemaValidatorTest extends TestCase
 
     public function testLoadSchemaWithInvalidJsonThrowsException(): void
     {
-        $reflection = new \ReflectionClass(SchemaValidator::class);
+        $reflection = new ReflectionClass(SchemaValidator::class);
         $schemaPathProperty = $reflection->getConstant('SCHEMA_PATH');
 
         // Backup the original schema file
@@ -124,7 +146,7 @@ class SchemaValidatorTest extends TestCase
         file_put_contents($schemaPathProperty, 'invalid json content');
 
         try {
-            $this->expectException(\JsonException::class);
+            $this->expectException(JsonException::class);
             $this->expectExceptionMessage('Syntax error');
 
             $this->schemaValidator->validate(['paths' => ['test']]);
@@ -144,7 +166,7 @@ class SchemaValidatorTest extends TestCase
             'strict' => null, // Invalid - should be boolean
         ];
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Configuration validation failed:');
 
         $this->schemaValidator->validate($dataWithNull);
@@ -161,7 +183,7 @@ class SchemaValidatorTest extends TestCase
         try {
             $this->schemaValidator->validate($invalidData);
             $this->fail('Expected RuntimeException was not thrown');
-        } catch (\RuntimeException $e) {
+        } catch (RuntimeException $e) {
             $message = $e->getMessage();
             $this->assertStringContainsString('Configuration validation failed:', $message);
             // The error message should contain multiple error lines
@@ -197,7 +219,7 @@ class SchemaValidatorTest extends TestCase
 
     public function testLoadSchemaFileReadFailureThrowsException(): void
     {
-        $reflection = new \ReflectionClass(SchemaValidator::class);
+        $reflection = new ReflectionClass(SchemaValidator::class);
         $schemaPathProperty = $reflection->getConstant('SCHEMA_PATH');
 
         // Backup the original schema file
@@ -210,7 +232,7 @@ class SchemaValidatorTest extends TestCase
         mkdir($schemaPathProperty);
 
         try {
-            $this->expectException(\RuntimeException::class);
+            $this->expectException(RuntimeException::class);
 
             $this->schemaValidator->validate(['paths' => ['test']]);
         } finally {

--- a/tests/src/Config/TranslationValidatorConfigTest.php
+++ b/tests/src/Config/TranslationValidatorConfigTest.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Config;
 
 use MoveElevator\ComposerTranslationValidator\Config\TranslationValidatorConfig;

--- a/tests/src/FileDetector/CollectorTest.php
+++ b/tests/src/FileDetector/CollectorTest.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\FileDetector;
 
 use MoveElevator\ComposerTranslationValidator\FileDetector\Collector;
@@ -10,6 +29,8 @@ use MoveElevator\ComposerTranslationValidator\Parser\XliffParser;
 use MoveElevator\ComposerTranslationValidator\Parser\YamlParser;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 
 final class CollectorTest extends TestCase
 {
@@ -209,9 +230,9 @@ final class CollectorTest extends TestCase
         $this->assertFileExists($this->tempDir.'/level1/level2/deep.xlf', 'deep.xlf should exist');
 
         // Debug: test RecursiveDirectoryIterator directly
-        $iterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($this->tempDir, \RecursiveDirectoryIterator::SKIP_DOTS),
-            \RecursiveIteratorIterator::LEAVES_ONLY
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($this->tempDir, RecursiveDirectoryIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::LEAVES_ONLY,
         );
         $foundFiles = [];
         foreach ($iterator as $file) {

--- a/tests/src/FileDetector/DirectoryFileDetectorTest.php
+++ b/tests/src/FileDetector/DirectoryFileDetectorTest.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\FileDetector;
 
 use MoveElevator\ComposerTranslationValidator\FileDetector\DirectoryFileDetector;

--- a/tests/src/FileDetector/FileDetectorRegistryTest.php
+++ b/tests/src/FileDetector/FileDetectorRegistryTest.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\FileDetector;
 
 use MoveElevator\ComposerTranslationValidator\FileDetector\DetectorInterface;
@@ -39,7 +58,7 @@ final class FileDetectorRegistryTest extends TestCase
             $this->assertContains(
                 DetectorInterface::class,
                 class_implements($detector) ?: [],
-                "Class {$detector} should implement DetectorInterface"
+                "Class {$detector} should implement DetectorInterface",
             );
         }
     }

--- a/tests/src/FileDetector/FileSetTest.php
+++ b/tests/src/FileDetector/FileSetTest.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\FileDetector;
 
 use MoveElevator\ComposerTranslationValidator\FileDetector\FileSet;

--- a/tests/src/FileDetector/PrefixFileDetectorTest.php
+++ b/tests/src/FileDetector/PrefixFileDetectorTest.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\FileDetector;
 
 use MoveElevator\ComposerTranslationValidator\FileDetector\PrefixFileDetector;

--- a/tests/src/FileDetector/SuffixFileDetectorTest.php
+++ b/tests/src/FileDetector/SuffixFileDetectorTest.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\FileDetector;
 
 use MoveElevator\ComposerTranslationValidator\FileDetector\SuffixFileDetector;

--- a/tests/src/Fixtures/config/auto-detect/translation-validator.php
+++ b/tests/src/Fixtures/config/auto-detect/translation-validator.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 use MoveElevator\ComposerTranslationValidator\Config\TranslationValidatorConfig;
 
 return (new TranslationValidatorConfig())

--- a/tests/src/Fixtures/config/invalid.php
+++ b/tests/src/Fixtures/config/invalid.php
@@ -2,4 +2,23 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 return 'This is not a TranslationValidatorConfig instance';

--- a/tests/src/Fixtures/config/valid.php
+++ b/tests/src/Fixtures/config/valid.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 use MoveElevator\ComposerTranslationValidator\Config\TranslationValidatorConfig;
 
 return (new TranslationValidatorConfig())

--- a/tests/src/Fixtures/recursive/level1/auth.de.php
+++ b/tests/src/Fixtures/recursive/level1/auth.de.php
@@ -1,5 +1,24 @@
 <?php
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 return [
     'login' => 'Anmelden',
     'logout' => 'Abmelden',

--- a/tests/src/Fixtures/recursive/level1/auth.en.php
+++ b/tests/src/Fixtures/recursive/level1/auth.en.php
@@ -1,5 +1,24 @@
 <?php
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 return [
     'login' => 'Login',
     'logout' => 'Logout',

--- a/tests/src/Fixtures/translations/php/fail/invalid.php
+++ b/tests/src/Fixtures/translations/php/fail/invalid.php
@@ -1,6 +1,24 @@
 <?php
 
-// This file does not return an array
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 echo 'This is not a valid translation file';
 
 return 'not an array';

--- a/tests/src/Fixtures/translations/php/fail/messages.de.php
+++ b/tests/src/Fixtures/translations/php/fail/messages.de.php
@@ -1,5 +1,24 @@
 <?php
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 return [
     'welcome' => 'Willkommen in unserer Anwendung!',
     'user' => [

--- a/tests/src/Fixtures/translations/php/fail/messages.en.php
+++ b/tests/src/Fixtures/translations/php/fail/messages.en.php
@@ -1,5 +1,24 @@
 <?php
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 return [
     'welcome' => 'Welcome to our application!',
     'user' => [

--- a/tests/src/Fixtures/translations/php/laravel/de/messages.php
+++ b/tests/src/Fixtures/translations/php/laravel/de/messages.php
@@ -1,5 +1,24 @@
 <?php
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 return [
     'welcome' => 'Willkommen!',
     'auth' => [

--- a/tests/src/Fixtures/translations/php/laravel/en/messages.php
+++ b/tests/src/Fixtures/translations/php/laravel/en/messages.php
@@ -1,5 +1,24 @@
 <?php
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 return [
     'welcome' => 'Welcome!',
     'auth' => [

--- a/tests/src/Fixtures/translations/php/success/messages.de.php
+++ b/tests/src/Fixtures/translations/php/success/messages.de.php
@@ -1,5 +1,24 @@
 <?php
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 return [
     'welcome' => 'Willkommen in unserer Anwendung!',
     'user' => [

--- a/tests/src/Fixtures/translations/php/success/messages.en.php
+++ b/tests/src/Fixtures/translations/php/success/messages.en.php
@@ -1,5 +1,24 @@
 <?php
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 return [
     'welcome' => 'Welcome to our application!',
     'user' => [

--- a/tests/src/Parser/AbstractParserTest.php
+++ b/tests/src/Parser/AbstractParserTest.php
@@ -2,10 +2,31 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Parser;
 
+use InvalidArgumentException;
 use MoveElevator\ComposerTranslationValidator\Parser\AbstractParser;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 // Concrete test class for testing AbstractParser
 class TestParser extends AbstractParser
@@ -52,7 +73,7 @@ final class AbstractParserTest extends TestCase
 
     public function testConstructorWithNonExistentFile(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('File "/non/existent/file.txt" does not exist.');
 
         new TestParser('/non/existent/file.txt');
@@ -64,7 +85,7 @@ final class AbstractParserTest extends TestCase
         file_put_contents($unreadableFile, 'test content');
         chmod($unreadableFile, 0000);
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('File "'.$unreadableFile.'" is not readable.');
 
         try {
@@ -80,7 +101,7 @@ final class AbstractParserTest extends TestCase
         $invalidFile = $this->tempDir.'/invalid.xyz';
         file_put_contents($invalidFile, 'test content');
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('File "'.$invalidFile.'" is not a valid file.');
 
         try {

--- a/tests/src/Parser/JsonParserTest.php
+++ b/tests/src/Parser/JsonParserTest.php
@@ -2,10 +2,31 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Parser;
 
+use InvalidArgumentException;
 use MoveElevator\ComposerTranslationValidator\Parser\JsonParser;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 final class JsonParserTest extends TestCase
 {
@@ -73,7 +94,7 @@ final class JsonParserTest extends TestCase
 
     public function testConstructorThrowsExceptionIfFileDoesNotExist(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageMatches('/File ".*" does not exist./');
         new JsonParser('/non/existent/file.json');
     }
@@ -84,7 +105,7 @@ final class JsonParserTest extends TestCase
         file_put_contents($unreadableFile, '{"key": "value"}');
         chmod($unreadableFile, 0000); // Make unreadable
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessageMatches('/File ".*" is not readable./');
         new JsonParser($unreadableFile);
     }
@@ -99,12 +120,12 @@ final class JsonParserTest extends TestCase
                 // Simulate the exact code path from JsonParser constructor
                 $content = @file_get_contents($filePath); // Suppress warning with @
                 if (false === $content) {
-                    throw new \RuntimeException("Failed to read file: {$filePath}");
+                    throw new RuntimeException("Failed to read file: {$filePath}");
                 }
             }
         };
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Failed to read file:');
         $validator->testFileGetContentsFalse('/non/existent/file.json');
     }
@@ -114,21 +135,21 @@ final class JsonParserTest extends TestCase
         $invalidFile = $this->tempDir.'/invalid.txt';
         file_put_contents($invalidFile, '{"key": "value"}');
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageMatches('/File ".*" is not a valid file./');
         new JsonParser($invalidFile);
     }
 
     public function testConstructorThrowsExceptionIfJsonIsInvalid(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessageMatches('/Failed to parse JSON file/');
         new JsonParser($this->invalidJsonFile);
     }
 
     public function testConstructorThrowsExceptionIfJsonIsNotObject(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessageMatches('/JSON file does not contain an object/');
         new JsonParser($this->nonObjectJsonFile);
     }
@@ -138,7 +159,7 @@ final class JsonParserTest extends TestCase
         $emptyFile = $this->tempDir.'/empty.json';
         file_put_contents($emptyFile, ''); // Empty file causes JSON syntax error
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessageMatches('/Failed to parse JSON file/');
         new JsonParser($emptyFile);
     }

--- a/tests/src/Parser/ParserCacheTest.php
+++ b/tests/src/Parser/ParserCacheTest.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Parser;
 
 use MoveElevator\ComposerTranslationValidator\Parser\ParserCache;

--- a/tests/src/Parser/ParserRegistryTest.php
+++ b/tests/src/Parser/ParserRegistryTest.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Parser;
 
 use MoveElevator\ComposerTranslationValidator\Parser\JsonParser;
@@ -70,7 +89,7 @@ final class ParserRegistryTest extends TestCase
             $this->assertContains(
                 ParserInterface::class,
                 class_implements($parser) ?: [],
-                "Class {$parser} should implement ParserInterface"
+                "Class {$parser} should implement ParserInterface",
             );
         }
     }

--- a/tests/src/Parser/PhpParserTest.php
+++ b/tests/src/Parser/PhpParserTest.php
@@ -2,10 +2,31 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Parser;
 
+use InvalidArgumentException;
 use MoveElevator\ComposerTranslationValidator\Parser\PhpParser;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 final class PhpParserTest extends TestCase
 {
@@ -26,7 +47,7 @@ final class PhpParserTest extends TestCase
 
     public function testConstructorWithNonExistentFile(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('File "/non/existent/file.php" does not exist.');
 
         new PhpParser('/non/existent/file.php');
@@ -34,7 +55,7 @@ final class PhpParserTest extends TestCase
 
     public function testConstructorWithInvalidExtension(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageMatches('/is not a valid file/');
 
         // Create a temporary file with wrong extension
@@ -52,7 +73,7 @@ final class PhpParserTest extends TestCase
     {
         $filePath = __DIR__.'/../Fixtures/translations/php/fail/invalid.php';
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('PHP translation file must return an array');
 
         new PhpParser($filePath);

--- a/tests/src/Parser/XliffParserTest.php
+++ b/tests/src/Parser/XliffParserTest.php
@@ -2,10 +2,31 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Parser;
 
+use InvalidArgumentException;
 use MoveElevator\ComposerTranslationValidator\Parser\XliffParser;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 final class XliffParserTest extends TestCase
 {
@@ -112,7 +133,7 @@ EOT;
 
     public function testConstructorThrowsExceptionIfFileDoesNotExist(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageMatches('/File ".*" does not exist./');
         new XliffParser('/non/existent/file.xlf');
     }
@@ -123,7 +144,7 @@ EOT;
         file_put_contents($unreadableFile, 'content');
         chmod($unreadableFile, 0000); // Make unreadable
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessageMatches('/File ".*" is not readable./');
         new XliffParser($unreadableFile);
     }
@@ -133,7 +154,7 @@ EOT;
         $invalidFile = $this->tempDir.'/invalid.txt';
         file_put_contents($invalidFile, 'content');
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageMatches('/File ".*" is not a valid file./');
         new XliffParser($invalidFile);
     }
@@ -232,12 +253,12 @@ EOT;
                 // Simulate the exact code path from XliffParser constructor
                 $xmlContent = @file_get_contents($filePath); // Suppress warning with @
                 if (false === $xmlContent) {
-                    throw new \InvalidArgumentException("Failed to read file: {$filePath}");
+                    throw new InvalidArgumentException("Failed to read file: {$filePath}");
                 }
             }
         };
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Failed to read file:');
         $validator->testFileGetContentsFalse('/non/existent/file.xlf');
     }
@@ -247,7 +268,7 @@ EOT;
         $invalidXmlFile = $this->tempDir.'/invalid.xlf';
         file_put_contents($invalidXmlFile, 'invalid xml content');
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Failed to parse XML content from file:');
         new XliffParser($invalidXmlFile);
     }

--- a/tests/src/Parser/YamlParserTest.php
+++ b/tests/src/Parser/YamlParserTest.php
@@ -2,10 +2,31 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Parser;
 
+use InvalidArgumentException;
 use MoveElevator\ComposerTranslationValidator\Parser\YamlParser;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 final class YamlParserTest extends TestCase
 {
@@ -75,7 +96,7 @@ EOT
 
     public function testConstructorThrowsExceptionIfFileDoesNotExist(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageMatches('/File ".*" does not exist./');
         new YamlParser('/non/existent/file.yaml');
     }
@@ -86,7 +107,7 @@ EOT
         file_put_contents($unreadableFile, 'content');
         chmod($unreadableFile, 0000); // Make unreadable
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessageMatches('/File ".*" is not readable./');
         new YamlParser($unreadableFile);
     }
@@ -96,14 +117,14 @@ EOT
         $invalidFile = $this->tempDir.'/invalid.txt';
         file_put_contents($invalidFile, 'content');
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageMatches('/File ".*" is not a valid file./');
         new YamlParser($invalidFile);
     }
 
     public function testConstructorThrowsExceptionIfYamlIsInvalid(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessageMatches('/Failed to parse YAML file/');
         new YamlParser($this->invalidYamlFile);
     }

--- a/tests/src/PluginExtendedTest.php
+++ b/tests/src/PluginExtendedTest.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests;
 
 use Composer\Composer;

--- a/tests/src/PluginTest.php
+++ b/tests/src/PluginTest.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests;
 
 use Composer\Plugin\Capability\CommandProvider;

--- a/tests/src/Result/AbstractValidationResultRendererTest.php
+++ b/tests/src/Result/AbstractValidationResultRendererTest.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Result;
 
 use MoveElevator\ComposerTranslationValidator\Result\AbstractValidationResultRenderer;

--- a/tests/src/Result/FormatTypeTest.php
+++ b/tests/src/Result/FormatTypeTest.php
@@ -2,16 +2,36 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Result;
 
 use MoveElevator\ComposerTranslationValidator\Result\FormatType;
 use PHPUnit\Framework\TestCase;
+use ValueError;
 
 final class FormatTypeTest extends TestCase
 {
     public function testFromInvalidValueThrowsException(): void
     {
-        $this->expectException(\ValueError::class);
+        $this->expectException(ValueError::class);
         FormatType::from('invalid');
     }
 

--- a/tests/src/Result/IssueTest.php
+++ b/tests/src/Result/IssueTest.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Result;
 
 use MoveElevator\ComposerTranslationValidator\Result\Issue;

--- a/tests/src/Result/OutputTest.php
+++ b/tests/src/Result/OutputTest.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Result;
 
 use MoveElevator\ComposerTranslationValidator\Result\FormatType;
@@ -39,7 +58,7 @@ final class OutputTest extends TestCase
             $this->output,
             $this->inputMock,
             FormatType::CLI,
-            $validationResult
+            $validationResult,
         );
 
         $exitCode = $output->summarize();
@@ -59,7 +78,7 @@ final class OutputTest extends TestCase
             $this->output,
             $this->inputMock,
             FormatType::JSON,
-            $validationResult
+            $validationResult,
         );
 
         $exitCode = $output->summarize();
@@ -84,7 +103,7 @@ final class OutputTest extends TestCase
             $this->output,
             $this->inputMock,
             FormatType::CLI,
-            $validationResult
+            $validationResult,
         );
 
         $exitCode = $output->summarize();
@@ -104,7 +123,7 @@ final class OutputTest extends TestCase
             $this->output,
             $this->inputMock,
             FormatType::CLI,
-            $validationResult
+            $validationResult,
         );
 
         $exitCode = $output->summarize();
@@ -124,7 +143,7 @@ final class OutputTest extends TestCase
             $this->output,
             $this->inputMock,
             FormatType::JSON,
-            $validationResult
+            $validationResult,
         );
 
         $exitCode = $output->summarize();
@@ -148,7 +167,7 @@ final class OutputTest extends TestCase
             $this->output,
             $this->inputMock,
             FormatType::JSON,
-            $validationResult
+            $validationResult,
         );
 
         $exitCode = $output->summarize();
@@ -173,7 +192,7 @@ final class OutputTest extends TestCase
             $this->inputMock,
             FormatType::CLI,
             $validationResult,
-            true // dry run
+            true, // dry run
         );
 
         $exitCode = $output->summarize();
@@ -195,7 +214,7 @@ final class OutputTest extends TestCase
             FormatType::CLI,
             $validationResult,
             false, // not dry run
-            true   // strict mode
+            true,   // strict mode
         );
 
         $exitCode = $output->summarize();

--- a/tests/src/Result/ValidationResultCliRendererTest.php
+++ b/tests/src/Result/ValidationResultCliRendererTest.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Result;
 
 use MoveElevator\ComposerTranslationValidator\FileDetector\FileSet;
@@ -12,6 +31,7 @@ use MoveElevator\ComposerTranslationValidator\Validator\ResultType;
 use MoveElevator\ComposerTranslationValidator\Validator\ValidatorInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -30,7 +50,7 @@ class ValidationResultCliRendererTest extends TestCase
         $this->input = $input;
         $this->renderer = new ValidationResultCliRenderer(
             $this->output,
-            $input
+            $input,
         );
     }
 
@@ -61,7 +81,7 @@ class ValidationResultCliRendererTest extends TestCase
         $validationResult = new ValidationResult(
             $validators,
             ResultType::ERROR,
-            $pairs
+            $pairs,
         );
 
         $exitCode = $this->renderer->render($validationResult);
@@ -80,7 +100,7 @@ class ValidationResultCliRendererTest extends TestCase
         $renderer = new ValidationResultCliRenderer(
             $this->output,
             $input,
-            true  // dry run
+            true,  // dry run
         );
 
         $validator = $this->createMockValidator();
@@ -91,7 +111,7 @@ class ValidationResultCliRendererTest extends TestCase
         $validationResult = new ValidationResult(
             [$validator],
             ResultType::ERROR,
-            [['validator' => $validator, 'fileSet' => $fileSet]]
+            [['validator' => $validator, 'fileSet' => $fileSet]],
         );
 
         $exitCode = $renderer->render($validationResult);
@@ -108,7 +128,7 @@ class ValidationResultCliRendererTest extends TestCase
             $this->output,
             $input,
             false, // dry run
-            true   // strict
+            true,   // strict
         );
 
         $validator = $this->createMockValidator();
@@ -119,7 +139,7 @@ class ValidationResultCliRendererTest extends TestCase
         $validationResult = new ValidationResult(
             [$validator],
             ResultType::WARNING,
-            [['validator' => $validator, 'fileSet' => $fileSet]]
+            [['validator' => $validator, 'fileSet' => $fileSet]],
         );
 
         $exitCode = $renderer->render($validationResult);
@@ -140,7 +160,7 @@ class ValidationResultCliRendererTest extends TestCase
         $validationResult = new ValidationResult(
             [$validator],
             ResultType::ERROR,
-            [['validator' => $validator, 'fileSet' => $fileSet]]
+            [['validator' => $validator, 'fileSet' => $fileSet]],
         );
 
         $this->renderer->render($validationResult);
@@ -161,7 +181,7 @@ class ValidationResultCliRendererTest extends TestCase
         $validationResult = new ValidationResult(
             [$validator],
             ResultType::WARNING,
-            [['validator' => $validator, 'fileSet' => $fileSet]]
+            [['validator' => $validator, 'fileSet' => $fileSet]],
         );
 
         $exitCode = $this->renderer->render($validationResult);
@@ -198,7 +218,7 @@ class ValidationResultCliRendererTest extends TestCase
             [
                 ['validator' => $validator1, 'fileSet' => $fileSet1],
                 ['validator' => $validator1, 'fileSet' => $fileSet2],
-            ]
+            ],
         );
 
         $this->renderer->render($validationResult);
@@ -222,7 +242,7 @@ class ValidationResultCliRendererTest extends TestCase
         $validationResult = new ValidationResult(
             [$validator],
             ResultType::ERROR,
-            [['validator' => $validator, 'fileSet' => $fileSet]]
+            [['validator' => $validator, 'fileSet' => $fileSet]],
         );
 
         // Test compact mode (non-verbose)
@@ -258,7 +278,7 @@ class ValidationResultCliRendererTest extends TestCase
         $validationResult = new ValidationResult(
             [$validator],
             ResultType::ERROR,
-            [['validator' => $validator, 'fileSet' => $fileSet]]
+            [['validator' => $validator, 'fileSet' => $fileSet]],
         );
 
         $this->output->setVerbosity(OutputInterface::VERBOSITY_NORMAL);
@@ -281,7 +301,7 @@ class ValidationResultCliRendererTest extends TestCase
         $validationResult = new ValidationResult(
             [$validator],
             ResultType::ERROR,
-            [['validator' => $validator, 'fileSet' => $fileSet]]
+            [['validator' => $validator, 'fileSet' => $fileSet]],
         );
 
         $this->renderer->render($validationResult);
@@ -306,7 +326,7 @@ class ValidationResultCliRendererTest extends TestCase
             ['validator' => $validator2, 'issue' => $issue2],
         ];
 
-        $reflection = new \ReflectionClass($this->renderer);
+        $reflection = new ReflectionClass($this->renderer);
         $method = $reflection->getMethod('sortIssuesBySeverity');
         $method->setAccessible(true);
 
@@ -326,7 +346,7 @@ class ValidationResultCliRendererTest extends TestCase
             'TestValidator3' => ['validator' => $this->createMockValidator(), 'issues' => []],
         ];
 
-        $reflection = new \ReflectionClass($this->renderer);
+        $reflection = new ReflectionClass($this->renderer);
         $method = $reflection->getMethod('sortValidatorGroupsBySeverity');
         $method->setAccessible(true);
 
@@ -341,7 +361,7 @@ class ValidationResultCliRendererTest extends TestCase
 
     public function testGetValidatorSeverity(): void
     {
-        $reflection = new \ReflectionClass($this->renderer);
+        $reflection = new ReflectionClass($this->renderer);
         $method = $reflection->getMethod('getValidatorSeverity');
         $method->setAccessible(true);
 
@@ -359,7 +379,7 @@ class ValidationResultCliRendererTest extends TestCase
         $validator = $this->createMockValidator();
         $issue = new Issue('test.xlf', ['message' => 'Test error'], 'TestParser', 'TestValidator');
 
-        $reflection = new \ReflectionClass($this->renderer);
+        $reflection = new ReflectionClass($this->renderer);
         $method = $reflection->getMethod('formatIssueMessage');
         $method->setAccessible(true);
 
@@ -378,7 +398,7 @@ class ValidationResultCliRendererTest extends TestCase
             0.123,  // 123ms
             5,      // files
             15,     // keys
-            3       // validators
+            3,       // validators
         );
 
         $validationResult = new ValidationResult([], ResultType::SUCCESS, [], $statistics);
@@ -401,7 +421,7 @@ class ValidationResultCliRendererTest extends TestCase
             10,     // files
             50,     // keys
             4,      // validators
-            7       // parsers cached
+            7,       // parsers cached
         );
 
         $validationResult = new ValidationResult([], ResultType::SUCCESS, [], $statistics);
@@ -423,7 +443,7 @@ class ValidationResultCliRendererTest extends TestCase
             0.123,
             5,
             15,
-            3
+            3,
         );
 
         $validationResult = new ValidationResult([], ResultType::SUCCESS, [], $statistics);
@@ -465,7 +485,7 @@ class ValidationResultCliRendererTest extends TestCase
             0.089,  // 89ms
             2,      // files
             8,      // keys
-            2       // validators
+            2,       // validators
         );
 
         $fileSet = new FileSet('TestParser', '/test/path', 'setKey', ['test.xlf']);
@@ -473,7 +493,7 @@ class ValidationResultCliRendererTest extends TestCase
             [$validator],
             ResultType::ERROR,
             [['validator' => $validator, 'fileSet' => $fileSet]],
-            $statistics
+            $statistics,
         );
 
         $this->output->setVerbosity(OutputInterface::VERBOSITY_VERBOSE);
@@ -529,7 +549,7 @@ class ValidationResultCliRendererTest extends TestCase
         $validationResult = new ValidationResult(
             [$validator],
             ResultType::WARNING,
-            [['validator' => $validator, 'fileSet' => $fileSet]]
+            [['validator' => $validator, 'fileSet' => $fileSet]],
         );
 
         $this->output->setVerbosity(OutputInterface::VERBOSITY_NORMAL);
@@ -554,7 +574,7 @@ class ValidationResultCliRendererTest extends TestCase
         $validationResult = new ValidationResult(
             [$validator],
             ResultType::ERROR,
-            [['validator' => $validator, 'fileSet' => $fileSet]]
+            [['validator' => $validator, 'fileSet' => $fileSet]],
         );
 
         $this->output->setVerbosity(OutputInterface::VERBOSITY_NORMAL);
@@ -576,7 +596,7 @@ class ValidationResultCliRendererTest extends TestCase
             $this->output,
             $input,
             true, // dry run
-            false
+            false,
         );
 
         $validationResult = new ValidationResult([], ResultType::ERROR);
@@ -596,7 +616,7 @@ class ValidationResultCliRendererTest extends TestCase
             $this->output,
             $input,
             false, // not dry run
-            false  // not strict
+            false,  // not strict
         );
 
         $this->output->setVerbosity(OutputInterface::VERBOSITY_NORMAL);
@@ -616,7 +636,7 @@ class ValidationResultCliRendererTest extends TestCase
             $this->output,
             $input,
             false, // not dry run
-            true   // strict mode
+            true,   // strict mode
         );
 
         $this->output->setVerbosity(OutputInterface::VERBOSITY_NORMAL);
@@ -636,7 +656,7 @@ class ValidationResultCliRendererTest extends TestCase
             $this->output,
             $input,
             false, // not dry run
-            false  // not strict
+            false,  // not strict
         );
 
         $this->output->setVerbosity(OutputInterface::VERBOSITY_NORMAL);
@@ -658,7 +678,7 @@ class ValidationResultCliRendererTest extends TestCase
             $this->output,
             $input,
             false, // not dry run
-            false  // not strict
+            false,  // not strict
         );
 
         $this->output->setVerbosity(OutputInterface::VERBOSITY_VERBOSE);
@@ -700,7 +720,7 @@ class ValidationResultCliRendererTest extends TestCase
             [
                 ['validator' => $validator1, 'fileSet' => $fileSet],
                 ['validator' => $validator2, 'fileSet' => $fileSet],
-            ]
+            ],
         );
 
         $this->output->setVerbosity(OutputInterface::VERBOSITY_VERBOSE);
@@ -735,7 +755,7 @@ class ValidationResultCliRendererTest extends TestCase
         $validationResult = new ValidationResult(
             [$validator],
             ResultType::ERROR,
-            [['validator' => $validator, 'fileSet' => $fileSet]]
+            [['validator' => $validator, 'fileSet' => $fileSet]],
         );
 
         $this->output->setVerbosity(OutputInterface::VERBOSITY_VERBOSE);
@@ -765,7 +785,7 @@ class ValidationResultCliRendererTest extends TestCase
         $validationResult = new ValidationResult(
             [$validator],
             ResultType::WARNING,
-            [['validator' => $validator, 'fileSet' => $fileSet]]
+            [['validator' => $validator, 'fileSet' => $fileSet]],
         );
 
         $this->output->setVerbosity(OutputInterface::VERBOSITY_NORMAL);
@@ -810,7 +830,7 @@ class ValidationResultCliRendererTest extends TestCase
         $validationResult = new ValidationResult(
             [$validator],
             ResultType::ERROR,
-            [['validator' => $validator, 'fileSet' => $fileSet]]
+            [['validator' => $validator, 'fileSet' => $fileSet]],
         );
 
         $this->output->setVerbosity(OutputInterface::VERBOSITY_NORMAL);

--- a/tests/src/Result/ValidationResultJsonRendererTest.php
+++ b/tests/src/Result/ValidationResultJsonRendererTest.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Result;
 
 use MoveElevator\ComposerTranslationValidator\FileDetector\FileSet;
@@ -24,7 +43,7 @@ class ValidationResultJsonRendererTest extends TestCase
     {
         $this->output = new BufferedOutput();
         $this->renderer = new ValidationResultJsonRenderer(
-            $this->output
+            $this->output,
         );
     }
 
@@ -62,7 +81,7 @@ class ValidationResultJsonRendererTest extends TestCase
         $validationResult = new ValidationResult(
             $validators,
             ResultType::ERROR,
-            $pairs
+            $pairs,
         );
 
         $exitCode = $this->renderer->render($validationResult);
@@ -88,7 +107,7 @@ class ValidationResultJsonRendererTest extends TestCase
     {
         $renderer = new ValidationResultJsonRenderer(
             $this->output,
-            true  // dry run
+            true,  // dry run
         );
 
         $validator = $this->createMockValidator();
@@ -101,7 +120,7 @@ class ValidationResultJsonRendererTest extends TestCase
         $validationResult = new ValidationResult(
             [$validator],
             ResultType::ERROR,
-            [['validator' => $validator, 'fileSet' => $fileSet]]
+            [['validator' => $validator, 'fileSet' => $fileSet]],
         );
 
         $exitCode = $renderer->render($validationResult);
@@ -120,7 +139,7 @@ class ValidationResultJsonRendererTest extends TestCase
         $renderer = new ValidationResultJsonRenderer(
             $this->output,
             false, // dry run
-            true   // strict
+            true,   // strict
         );
 
         $validator = $this->createMockValidator();
@@ -133,7 +152,7 @@ class ValidationResultJsonRendererTest extends TestCase
         $validationResult = new ValidationResult(
             [$validator],
             ResultType::WARNING,
-            [['validator' => $validator, 'fileSet' => $fileSet]]
+            [['validator' => $validator, 'fileSet' => $fileSet]],
         );
 
         $exitCode = $renderer->render($validationResult);
@@ -152,7 +171,7 @@ class ValidationResultJsonRendererTest extends TestCase
         $renderer = new ValidationResultJsonRenderer(
             $this->output,
             false, // dry run
-            false  // strict
+            false,  // strict
         );
 
         $validator = $this->createMockValidator();
@@ -165,7 +184,7 @@ class ValidationResultJsonRendererTest extends TestCase
         $validationResult = new ValidationResult(
             [$validator],
             ResultType::WARNING,
-            [['validator' => $validator, 'fileSet' => $fileSet]]
+            [['validator' => $validator, 'fileSet' => $fileSet]],
         );
 
         $exitCode = $renderer->render($validationResult);
@@ -190,7 +209,7 @@ class ValidationResultJsonRendererTest extends TestCase
         $validationResult = new ValidationResult(
             [$validator],
             ResultType::ERROR,
-            [['validator' => $validator, 'fileSet' => $fileSet]]
+            [['validator' => $validator, 'fileSet' => $fileSet]],
         );
 
         $this->renderer->render($validationResult);
@@ -326,7 +345,7 @@ class ValidationResultJsonRendererTest extends TestCase
             [
                 ['validator' => $validator1, 'fileSet' => $fileSet],
                 ['validator' => $validator2, 'fileSet' => $fileSet],
-            ]
+            ],
         );
 
         $exitCode = $this->renderer->render($validationResult);
@@ -377,7 +396,7 @@ class ValidationResultJsonRendererTest extends TestCase
         $validationResult = new ValidationResult(
             [$validator],
             ResultType::ERROR,
-            [['validator' => $validator, 'fileSet' => $fileSet]]
+            [['validator' => $validator, 'fileSet' => $fileSet]],
         );
 
         $exitCode = $this->renderer->render($validationResult);
@@ -425,7 +444,7 @@ class ValidationResultJsonRendererTest extends TestCase
         $validationResult = new ValidationResult(
             [$validator],
             ResultType::SUCCESS,
-            [['validator' => $validator, 'fileSet' => $fileSet]]
+            [['validator' => $validator, 'fileSet' => $fileSet]],
         );
 
         $exitCode = $this->renderer->render($validationResult);

--- a/tests/src/Result/ValidationResultRendererFactoryTest.php
+++ b/tests/src/Result/ValidationResultRendererFactoryTest.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Result;
 
 use MoveElevator\ComposerTranslationValidator\Result\FormatType;
@@ -24,7 +43,7 @@ final class ValidationResultRendererFactoryTest extends TestCase
             $output,
             $input,
             false,
-            false
+            false,
         );
 
         $this->assertInstanceOf(ValidationResultCliRenderer::class, $renderer);
@@ -40,7 +59,7 @@ final class ValidationResultRendererFactoryTest extends TestCase
             $output,
             $input,
             true,
-            false
+            false,
         );
 
         $this->assertInstanceOf(ValidationResultCliRenderer::class, $renderer);
@@ -56,7 +75,7 @@ final class ValidationResultRendererFactoryTest extends TestCase
             $output,
             $input,
             false,
-            true
+            true,
         );
 
         $this->assertInstanceOf(ValidationResultCliRenderer::class, $renderer);
@@ -72,7 +91,7 @@ final class ValidationResultRendererFactoryTest extends TestCase
             $output,
             $input,
             false,
-            false
+            false,
         );
 
         $this->assertInstanceOf(ValidationResultJsonRenderer::class, $renderer);
@@ -88,7 +107,7 @@ final class ValidationResultRendererFactoryTest extends TestCase
             $output,
             $input,
             true,
-            false
+            false,
         );
 
         $this->assertInstanceOf(ValidationResultJsonRenderer::class, $renderer);
@@ -104,7 +123,7 @@ final class ValidationResultRendererFactoryTest extends TestCase
             $output,
             $input,
             false,
-            true
+            true,
         );
 
         $this->assertInstanceOf(ValidationResultJsonRenderer::class, $renderer);

--- a/tests/src/Result/ValidationResultTest.php
+++ b/tests/src/Result/ValidationResultTest.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Result;
 
 use MoveElevator\ComposerTranslationValidator\FileDetector\FileSet;
@@ -130,7 +149,7 @@ class ValidationResultTest extends TestCase
             1.23,
             5,
             10,
-            3
+            3,
         );
 
         $result = new ValidationResult($validators, $resultType, $pairs, $statistics);
@@ -154,7 +173,7 @@ class ValidationResultTest extends TestCase
             0.456,
             3,
             7,
-            2
+            2,
         );
 
         $result = new ValidationResult([], ResultType::SUCCESS, [], $statistics);

--- a/tests/src/Result/ValidationRunTest.php
+++ b/tests/src/Result/ValidationRunTest.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Result;
 
 use MoveElevator\ComposerTranslationValidator\FileDetector\FileSet;
@@ -13,6 +32,7 @@ use MoveElevator\ComposerTranslationValidator\Validator\ResultType;
 use MoveElevator\ComposerTranslationValidator\Validator\ValidatorInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ValidationRunTest extends TestCase
@@ -92,7 +112,7 @@ class ValidationRunTest extends TestCase
         $validationRun = new ValidationRun($this->logger);
         $result = $validationRun->executeFor(
             [$fileSet1, $fileSet2],
-            [$validatorClass1, $validatorClass2]
+            [$validatorClass1, $validatorClass2],
         );
 
         // Only validators with issues should be included
@@ -209,7 +229,7 @@ class ValidationRunTest extends TestCase
         $validationRun = new ValidationRun($this->logger);
         $result = $validationRun->executeFor(
             [$fileSet1, $fileSet2],
-            [$validatorClass1, $validatorClass2]
+            [$validatorClass1, $validatorClass2],
         );
 
         $statistics = $result->getStatistics();
@@ -345,9 +365,7 @@ class MockValidatorWithoutIssues implements ValidatorInterface
         return [];
     }
 
-    public function addIssue(Issue $issue): void
-    {
-    }
+    public function addIssue(Issue $issue): void {}
 
     public function formatIssueMessage(Issue $issue, string $prefix = '', bool $isVerbose = false): string
     {
@@ -364,9 +382,7 @@ class MockValidatorWithoutIssues implements ValidatorInterface
         return false;
     }
 
-    public function renderDetailedOutput(OutputInterface $output, array $issues): void
-    {
-    }
+    public function renderDetailedOutput(OutputInterface $output, array $issues): void {}
 
     public function getShortName(): string
     {
@@ -418,9 +434,7 @@ class MockValidatorWithIssues implements ValidatorInterface
         return [new Issue('test.xlf', ['mock'], 'MockParser', 'MockValidator')];
     }
 
-    public function addIssue(Issue $issue): void
-    {
-    }
+    public function addIssue(Issue $issue): void {}
 
     public function formatIssueMessage(Issue $issue, string $prefix = '', bool $isVerbose = false): string
     {
@@ -447,9 +461,7 @@ class MockValidatorWithIssues implements ValidatorInterface
         return false;
     }
 
-    public function renderDetailedOutput(OutputInterface $output, array $issues): void
-    {
-    }
+    public function renderDetailedOutput(OutputInterface $output, array $issues): void {}
 
     public function getShortName(): string
     {
@@ -466,7 +478,7 @@ class MockParserThatThrows implements ParserInterface
 
     public function extractKeys(): ?array
     {
-        throw new \RuntimeException('Parser failed');
+        throw new RuntimeException('Parser failed');
     }
 
     public function getContentByKey(string $key): ?string

--- a/tests/src/Result/ValidationStatisticsTest.php
+++ b/tests/src/Result/ValidationStatisticsTest.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Result;
 
 use MoveElevator\ComposerTranslationValidator\Result\ValidationStatistics;
@@ -20,7 +39,7 @@ class ValidationStatisticsTest extends TestCase
             $executionTime,
             $filesChecked,
             $keysChecked,
-            $validatorsRun
+            $validatorsRun,
         );
 
         $this->assertSame($executionTime, $statistics->getExecutionTime());
@@ -43,7 +62,7 @@ class ValidationStatisticsTest extends TestCase
             $filesChecked,
             $keysChecked,
             $validatorsRun,
-            $parsersCached
+            $parsersCached,
         );
 
         $this->assertSame($executionTime, $statistics->getExecutionTime());

--- a/tests/src/Utility/ClassUtilityTest.php
+++ b/tests/src/Utility/ClassUtilityTest.php
@@ -2,22 +2,36 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Utility;
 
 use MoveElevator\ComposerTranslationValidator\Utility\ClassUtility;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Stringable;
 
 // Dummy interface and classes for testing
-interface DummyInterface
-{
-}
-class ValidClass implements DummyInterface
-{
-}
-class InvalidClass
-{
-}
+interface DummyInterface {}
+class ValidClass implements DummyInterface {}
+class InvalidClass {}
 
 final class ClassUtilityTest extends TestCase
 {
@@ -69,7 +83,7 @@ final class ClassUtilityTest extends TestCase
     {
         $loggedMessages = [];
         $logger = $this->createMock(LoggerInterface::class);
-        $logger->method('error')->willReturnCallback(function (string|\Stringable $message) use (&$loggedMessages): void {
+        $logger->method('error')->willReturnCallback(function (string|Stringable $message) use (&$loggedMessages): void {
             $loggedMessages[] = $message;
         });
 
@@ -83,7 +97,7 @@ final class ClassUtilityTest extends TestCase
     {
         $loggedMessages = [];
         $logger = $this->createMock(LoggerInterface::class);
-        $logger->method('error')->willReturnCallback(function (string|\Stringable $message) use (&$loggedMessages): void {
+        $logger->method('error')->willReturnCallback(function (string|Stringable $message) use (&$loggedMessages): void {
             $loggedMessages[] = $message;
         });
 

--- a/tests/src/Utility/OutputUtilityTest.php
+++ b/tests/src/Utility/OutputUtilityTest.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Utility;
 
 use MoveElevator\ComposerTranslationValidator\Utility\OutputUtility;

--- a/tests/src/Utility/PathUtilityExtendedTest.php
+++ b/tests/src/Utility/PathUtilityExtendedTest.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Utility;
 
 use MoveElevator\ComposerTranslationValidator\Utility\PathUtility;

--- a/tests/src/Utility/PathUtilityTest.php
+++ b/tests/src/Utility/PathUtilityTest.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Utility;
 
 use MoveElevator\ComposerTranslationValidator\Utility\PathUtility;

--- a/tests/src/Validator/AbstractValidatorTest.php
+++ b/tests/src/Validator/AbstractValidatorTest.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Validator;
 
 use MoveElevator\ComposerTranslationValidator\Parser\ParserInterface;
@@ -11,6 +30,8 @@ use MoveElevator\ComposerTranslationValidator\Validator\ValidatorInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use ReflectionClass;
+use ReflectionException;
 
 // Dummy implementation of AbstractValidator for testing purposes
 class ConcreteValidator extends AbstractValidator implements ValidatorInterface
@@ -55,7 +76,7 @@ class ConcreteValidator extends AbstractValidator implements ValidatorInterface
                 'test_file.xlf',
                 ['postProcessIssue'],
                 'TestParser',
-                'ConcreteValidator'
+                'ConcreteValidator',
             ));
         }
     }
@@ -69,9 +90,7 @@ class ConcreteValidator extends AbstractValidator implements ValidatorInterface
 // Dummy Parser for testing
 class TestParser implements ParserInterface
 {
-    public function __construct(private readonly string $filePath)
-    {
-    }
+    public function __construct(private readonly string $filePath) {}
 
     public function extractKeys(): ?array
     {
@@ -122,7 +141,7 @@ final class AbstractValidatorTest extends TestCase
     public function testConstructorSetsLogger(): void
     {
         $validator = new ConcreteValidator($this->loggerMock);
-        $reflection = new \ReflectionClass($validator);
+        $reflection = new ReflectionClass($validator);
         $loggerProperty = $reflection->getProperty('logger');
         $loggerProperty->setAccessible(true);
         $this->assertSame($this->loggerMock, $loggerProperty->getValue($validator));
@@ -141,7 +160,7 @@ final class AbstractValidatorTest extends TestCase
     }
 
     /**
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testValidateWithIssues(): void
     {
@@ -162,7 +181,7 @@ final class AbstractValidatorTest extends TestCase
                     'type' => ConcreteValidator::class,
                 ],
             ],
-            $result
+            $result,
         );
     }
 
@@ -211,7 +230,7 @@ final class AbstractValidatorTest extends TestCase
             'test.xlf',
             ['error' => 'test'],
             'TestParser',
-            'TestValidator'
+            'TestValidator',
         );
         $validator->addIssue($issue);
 
@@ -232,13 +251,13 @@ final class AbstractValidatorTest extends TestCase
             'file1.xlf',
             ['error1'],
             'Parser1',
-            'Validator1'
+            'Validator1',
         );
         $issue2 = new Issue(
             'file2.xlf',
             ['error2'],
             'Parser2',
-            'Validator2'
+            'Validator2',
         );
 
         $validator->addIssue($issue1);
@@ -257,7 +276,7 @@ final class AbstractValidatorTest extends TestCase
             'test.xlf',
             ['test_error'],
             'TestParser',
-            'TestValidator'
+            'TestValidator',
         );
 
         $this->assertCount(0, $validator->getIssues());
@@ -275,14 +294,14 @@ final class AbstractValidatorTest extends TestCase
             'test.xlf',
             ['error'],
             'TestParser',
-            'TestValidator'
+            'TestValidator',
         );
         $validator->addIssue($issue);
 
         $this->assertTrue($validator->hasIssues());
 
         // Access resetState via reflection since it's protected
-        $reflection = new \ReflectionClass($validator);
+        $reflection = new ReflectionClass($validator);
         $resetStateMethod = $reflection->getMethod('resetState');
         $resetStateMethod->setAccessible(true);
         $resetStateMethod->invoke($validator);
@@ -300,7 +319,7 @@ final class AbstractValidatorTest extends TestCase
             'old.xlf',
             ['old_error'],
             'OldParser',
-            'OldValidator'
+            'OldValidator',
         );
         $validator->addIssue($issue);
 
@@ -325,7 +344,7 @@ final class AbstractValidatorTest extends TestCase
             ->method('debug')
             ->with($this->logicalOr(
                 $this->stringContains('is not supported by the validator'),
-                $this->stringContains('UnsupportedValidator')
+                $this->stringContains('UnsupportedValidator'),
             ));
 
         // Create a custom validator that doesn't support TestParser
@@ -340,9 +359,7 @@ final class AbstractValidatorTest extends TestCase
                 return []; // Empty - doesn't support any parser
             }
 
-            public function postProcess(): void
-            {
-            }
+            public function postProcess(): void {}
 
             public function getShortName(): string
             {

--- a/tests/src/Validator/DuplicateKeysValidatorTest.php
+++ b/tests/src/Validator/DuplicateKeysValidatorTest.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Validator;
 
 use MoveElevator\ComposerTranslationValidator\Parser\ParserInterface;
@@ -98,7 +117,7 @@ final class DuplicateKeysValidatorTest extends TestCase
             'test.xlf',
             ['duplicate_key' => 3, 'another_key' => 2],
             'XliffParser',
-            'DuplicateKeysValidator'
+            'DuplicateKeysValidator',
         );
 
         $result = $validator->formatIssueMessage($issue);

--- a/tests/src/Validator/DuplicateValuesValidatorTest.php
+++ b/tests/src/Validator/DuplicateValuesValidatorTest.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Validator;
 
 use MoveElevator\ComposerTranslationValidator\Parser\ParserInterface;
@@ -12,6 +31,7 @@ use MoveElevator\ComposerTranslationValidator\Validator\ResultType;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use ReflectionClass;
 
 final class DuplicateValuesValidatorTest extends TestCase
 {
@@ -39,7 +59,7 @@ final class DuplicateValuesValidatorTest extends TestCase
         $validator->processFile($parser);
 
         // Access protected property to check internal state
-        $reflection = new \ReflectionClass($validator);
+        $reflection = new ReflectionClass($validator);
         $valuesArrayProperty = $reflection->getProperty('valuesArray');
         $valuesArrayProperty->setAccessible(true);
         $valuesArray = $valuesArrayProperty->getValue($validator);
@@ -64,7 +84,7 @@ final class DuplicateValuesValidatorTest extends TestCase
         $validator = new DuplicateValuesValidator($this->loggerMock);
         $validator->processFile($parser);
 
-        $reflection = new \ReflectionClass($validator);
+        $reflection = new ReflectionClass($validator);
         $valuesArrayProperty = $reflection->getProperty('valuesArray');
         $valuesArrayProperty->setAccessible(true);
         $valuesArray = $valuesArrayProperty->getValue($validator);
@@ -93,7 +113,7 @@ final class DuplicateValuesValidatorTest extends TestCase
         $validator = new DuplicateValuesValidator($this->loggerMock);
         $validator->processFile($parser);
 
-        $reflection = new \ReflectionClass($validator);
+        $reflection = new ReflectionClass($validator);
         $valuesArrayProperty = $reflection->getProperty('valuesArray');
         $valuesArrayProperty->setAccessible(true);
         $valuesArray = $valuesArrayProperty->getValue($validator);
@@ -106,7 +126,7 @@ final class DuplicateValuesValidatorTest extends TestCase
         $validator = new DuplicateValuesValidator($this->loggerMock);
 
         // Manually set valuesArray to simulate previous processFile calls
-        $reflection = new \ReflectionClass($validator);
+        $reflection = new ReflectionClass($validator);
         $valuesArrayProperty = $reflection->getProperty('valuesArray');
         $valuesArrayProperty->setAccessible(true);
         $valuesArrayProperty->setValue($validator, [
@@ -152,7 +172,7 @@ final class DuplicateValuesValidatorTest extends TestCase
         $validator = new DuplicateValuesValidator($this->loggerMock);
 
         // Manually set valuesArray with no duplicates
-        $reflection = new \ReflectionClass($validator);
+        $reflection = new ReflectionClass($validator);
         $valuesArrayProperty = $reflection->getProperty('valuesArray');
         $valuesArrayProperty->setAccessible(true);
         $valuesArrayProperty->setValue($validator, [
@@ -177,7 +197,7 @@ final class DuplicateValuesValidatorTest extends TestCase
         $validator = new DuplicateValuesValidator($logger);
 
         // Manually set valuesArray to simulate previous validation
-        $reflection = new \ReflectionClass($validator);
+        $reflection = new ReflectionClass($validator);
         $valuesArrayProperty = $reflection->getProperty('valuesArray');
         $valuesArrayProperty->setAccessible(true);
         $valuesArrayProperty->setValue($validator, [
@@ -235,7 +255,7 @@ final class DuplicateValuesValidatorTest extends TestCase
             'test.xlf',
             ['duplicate_value' => ['key1', 'key2'], 'another_value' => ['key3', 'key4']],
             'XliffParser',
-            'DuplicateValuesValidator'
+            'DuplicateValuesValidator',
         );
 
         $result = $validator->formatIssueMessage($issue);
@@ -264,7 +284,7 @@ final class DuplicateValuesValidatorTest extends TestCase
         $validator->processFile($parser);
 
         // Access protected property to check internal state
-        $reflection = new \ReflectionClass($validator);
+        $reflection = new ReflectionClass($validator);
         $valuesArrayProperty = $reflection->getProperty('valuesArray');
         $valuesArrayProperty->setAccessible(true);
         $valuesArray = $valuesArrayProperty->getValue($validator);

--- a/tests/src/Validator/EmptyValuesValidatorTest.php
+++ b/tests/src/Validator/EmptyValuesValidatorTest.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Validator;
 
 use MoveElevator\ComposerTranslationValidator\Parser\JsonParser;
@@ -153,7 +172,7 @@ final class EmptyValuesValidatorTest extends TestCase
             'test.xlf',
             ['empty_key' => ''],
             'XliffParser',
-            'EmptyValuesValidator'
+            'EmptyValuesValidator',
         );
 
         $result = $validator->formatIssueMessage($issue);
@@ -173,7 +192,7 @@ final class EmptyValuesValidatorTest extends TestCase
             'test.xlf',
             ['whitespace_key' => '   '],
             'XliffParser',
-            'EmptyValuesValidator'
+            'EmptyValuesValidator',
         );
 
         $result = $validator->formatIssueMessage($issue);
@@ -193,7 +212,7 @@ final class EmptyValuesValidatorTest extends TestCase
             'test.xlf',
             ['empty_key' => '', 'whitespace_key' => '  '],
             'XliffParser',
-            'EmptyValuesValidator'
+            'EmptyValuesValidator',
         );
 
         $result = $validator->formatIssueMessage($issue);
@@ -213,7 +232,7 @@ final class EmptyValuesValidatorTest extends TestCase
             'test.xlf',
             ['empty_key' => ''],
             'XliffParser',
-            'EmptyValuesValidator'
+            'EmptyValuesValidator',
         );
 
         $result = $validator->formatIssueMessage($issue, '(TestPrefix) ');

--- a/tests/src/Validator/EncodingValidatorTest.php
+++ b/tests/src/Validator/EncodingValidatorTest.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Validator;
 
 use MoveElevator\ComposerTranslationValidator\Parser\JsonParser;
@@ -11,6 +30,7 @@ use MoveElevator\ComposerTranslationValidator\Parser\YamlParser;
 use MoveElevator\ComposerTranslationValidator\Result\Issue;
 use MoveElevator\ComposerTranslationValidator\Validator\EncodingValidator;
 use MoveElevator\ComposerTranslationValidator\Validator\ResultType;
+use Normalizer;
 use PHPUnit\Framework\TestCase;
 
 final class EncodingValidatorTest extends TestCase
@@ -122,7 +142,7 @@ final class EncodingValidatorTest extends TestCase
 
         $filePath = $this->testFilesPath.'/unicode-norm.yaml';
         // Create content with NFD normalization (decomposed)
-        $content = 'key: '.\Normalizer::normalize('café', \Normalizer::FORM_D);
+        $content = 'key: '.Normalizer::normalize('café', Normalizer::FORM_D);
         file_put_contents($filePath, $content);
 
         $parser = new YamlParser($filePath);
@@ -186,7 +206,7 @@ final class EncodingValidatorTest extends TestCase
                 $content = @file_get_contents($file->getFilePath()); // Suppress warning with @
                 if (false === $content) {
                     $this->logger?->error(
-                        'Could not read file content: '.$file->getFileName()
+                        'Could not read file content: '.$file->getFileName(),
                     );
 
                     return [];

--- a/tests/src/Validator/MismatchValidatorTest.php
+++ b/tests/src/Validator/MismatchValidatorTest.php
@@ -2,12 +2,32 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Validator;
 
 use MoveElevator\ComposerTranslationValidator\Parser\ParserInterface;
 use MoveElevator\ComposerTranslationValidator\Validator\MismatchValidator;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use ReflectionClass;
 
 final class MismatchValidatorTest extends TestCase
 {
@@ -28,7 +48,7 @@ final class MismatchValidatorTest extends TestCase
         $validator->processFile($parser2);
 
         // Accessing protected property for testing purposes
-        $reflection = new \ReflectionClass($validator);
+        $reflection = new ReflectionClass($validator);
         $keyArrayProperty = $reflection->getProperty('keyArray');
         $keyArrayProperty->setAccessible(true);
         $keyArray = $keyArrayProperty->getValue($validator);
@@ -38,7 +58,7 @@ final class MismatchValidatorTest extends TestCase
                 'file1.xlf' => ['key1' => null, 'key2' => null],
                 'file2.xlf' => ['key2' => null, 'key3' => null],
             ],
-            $keyArray
+            $keyArray,
         );
     }
 
@@ -78,7 +98,7 @@ final class MismatchValidatorTest extends TestCase
         $validator->postProcess();
 
         // Accessing protected property for testing purposes
-        $reflection = new \ReflectionClass($validator);
+        $reflection = new ReflectionClass($validator);
         $issuesProperty = $reflection->getProperty('issues');
         $issuesProperty->setAccessible(true);
         $issues = $issuesProperty->getValue($validator);
@@ -144,7 +164,7 @@ final class MismatchValidatorTest extends TestCase
         $validator->postProcess();
 
         // Accessing protected property for testing purposes
-        $reflection = new \ReflectionClass($validator);
+        $reflection = new ReflectionClass($validator);
         $issuesProperty = $reflection->getProperty('issues');
         $issuesProperty->setAccessible(true);
         $issues = $issuesProperty->getValue($validator);
@@ -158,7 +178,7 @@ final class MismatchValidatorTest extends TestCase
         $validator = new MismatchValidator($logger);
 
         // Manually set keyArray to simulate previous validation
-        $reflection = new \ReflectionClass($validator);
+        $reflection = new ReflectionClass($validator);
         $keyArrayProperty = $reflection->getProperty('keyArray');
         $keyArrayProperty->setAccessible(true);
         $keyArrayProperty->setValue($validator, [
@@ -210,7 +230,7 @@ final class MismatchValidatorTest extends TestCase
                 ],
             ],
             '',
-            'MismatchValidator'
+            'MismatchValidator',
         );
         $validator->addIssue($issue);
 
@@ -218,7 +238,7 @@ final class MismatchValidatorTest extends TestCase
             'TestParser',
             '/test/path',
             'setKey',
-            ['file1.xlf', 'file2.xlf']
+            ['file1.xlf', 'file2.xlf'],
         );
 
         $distribution = $validator->distributeIssuesForDisplay($fileSet);
@@ -256,7 +276,7 @@ final class MismatchValidatorTest extends TestCase
                 ],
             ],
             '',
-            'MismatchValidator'
+            'MismatchValidator',
         );
 
         $validator->renderDetailedOutput($output, [$issue]);
@@ -287,7 +307,7 @@ final class MismatchValidatorTest extends TestCase
                 ],
             ],
             'TestParser',
-            'MismatchValidator'
+            'MismatchValidator',
         );
 
         $result = $validator->formatIssueMessage($issue);

--- a/tests/src/Validator/PlaceholderConsistencyValidatorTest.php
+++ b/tests/src/Validator/PlaceholderConsistencyValidatorTest.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Validator;
 
 use MoveElevator\ComposerTranslationValidator\FileDetector\FileSet;
@@ -15,6 +34,7 @@ use MoveElevator\ComposerTranslationValidator\Validator\PlaceholderConsistencyVa
 use MoveElevator\ComposerTranslationValidator\Validator\ResultType;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use ReflectionClass;
 use Symfony\Component\Console\Output\BufferedOutput;
 
 final class PlaceholderConsistencyValidatorTest extends TestCase
@@ -112,7 +132,7 @@ final class PlaceholderConsistencyValidatorTest extends TestCase
         $logger = $this->createMock(LoggerInterface::class);
         $validator = new PlaceholderConsistencyValidator($logger);
 
-        $reflectionClass = new \ReflectionClass($validator);
+        $reflectionClass = new ReflectionClass($validator);
         $method = $reflectionClass->getMethod('extractPlaceholders');
         $method->setAccessible(true);
 
@@ -135,7 +155,7 @@ final class PlaceholderConsistencyValidatorTest extends TestCase
         $logger = $this->createMock(LoggerInterface::class);
         $validator = new PlaceholderConsistencyValidator($logger);
 
-        $reflectionClass = new \ReflectionClass($validator);
+        $reflectionClass = new ReflectionClass($validator);
         $method = $reflectionClass->getMethod('extractPlaceholders');
         $method->setAccessible(true);
 
@@ -155,7 +175,7 @@ final class PlaceholderConsistencyValidatorTest extends TestCase
         $logger = $this->createMock(LoggerInterface::class);
         $validator = new PlaceholderConsistencyValidator($logger);
 
-        $reflectionClass = new \ReflectionClass($validator);
+        $reflectionClass = new ReflectionClass($validator);
         $method = $reflectionClass->getMethod('extractPlaceholders');
         $method->setAccessible(true);
 
@@ -175,7 +195,7 @@ final class PlaceholderConsistencyValidatorTest extends TestCase
         $logger = $this->createMock(LoggerInterface::class);
         $validator = new PlaceholderConsistencyValidator($logger);
 
-        $reflectionClass = new \ReflectionClass($validator);
+        $reflectionClass = new ReflectionClass($validator);
         $method = $reflectionClass->getMethod('extractPlaceholders');
         $method->setAccessible(true);
 
@@ -195,7 +215,7 @@ final class PlaceholderConsistencyValidatorTest extends TestCase
         $logger = $this->createMock(LoggerInterface::class);
         $validator = new PlaceholderConsistencyValidator($logger);
 
-        $reflectionClass = new \ReflectionClass($validator);
+        $reflectionClass = new ReflectionClass($validator);
         $method = $reflectionClass->getMethod('extractPlaceholders');
         $method->setAccessible(true);
 
@@ -215,7 +235,7 @@ final class PlaceholderConsistencyValidatorTest extends TestCase
         $logger = $this->createMock(LoggerInterface::class);
         $validator = new PlaceholderConsistencyValidator($logger);
 
-        $reflectionClass = new \ReflectionClass($validator);
+        $reflectionClass = new ReflectionClass($validator);
         $method = $reflectionClass->getMethod('extractPlaceholders');
         $method->setAccessible(true);
 
@@ -274,7 +294,7 @@ final class PlaceholderConsistencyValidatorTest extends TestCase
                 ],
             ],
             'XliffParser',
-            'PlaceholderConsistencyValidator'
+            'PlaceholderConsistencyValidator',
         );
 
         $result = $validator->formatIssueMessage($issue);
@@ -298,7 +318,7 @@ final class PlaceholderConsistencyValidatorTest extends TestCase
                 'inconsistencies' => ['Some inconsistency'],
             ],
             'XliffParser',
-            'PlaceholderConsistencyValidator'
+            'PlaceholderConsistencyValidator',
         );
 
         $result = $validator->formatIssueMessage($issue, '(TestPrefix) ');
@@ -322,7 +342,7 @@ final class PlaceholderConsistencyValidatorTest extends TestCase
                 ],
             ],
             '',
-            'PlaceholderConsistencyValidator'
+            'PlaceholderConsistencyValidator',
         );
 
         $validator->addIssue($issue);
@@ -355,7 +375,7 @@ final class PlaceholderConsistencyValidatorTest extends TestCase
                 ],
             ],
             'XliffParser',
-            'PlaceholderConsistencyValidator'
+            'PlaceholderConsistencyValidator',
         );
 
         $output = new BufferedOutput();
@@ -382,7 +402,7 @@ final class PlaceholderConsistencyValidatorTest extends TestCase
 
         $validator->processFile($parser);
 
-        $reflectionClass = new \ReflectionClass($validator);
+        $reflectionClass = new ReflectionClass($validator);
         $property = $reflectionClass->getProperty('keyData');
         $property->setAccessible(true);
 
@@ -400,7 +420,7 @@ final class PlaceholderConsistencyValidatorTest extends TestCase
         $logger = $this->createMock(LoggerInterface::class);
         $validator = new PlaceholderConsistencyValidator($logger);
 
-        $reflectionClass = new \ReflectionClass($validator);
+        $reflectionClass = new ReflectionClass($validator);
         $method = $reflectionClass->getMethod('findPlaceholderInconsistencies');
         $method->setAccessible(true);
 

--- a/tests/src/Validator/ResultTypeTest.php
+++ b/tests/src/Validator/ResultTypeTest.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Validator;
 
 use MoveElevator\ComposerTranslationValidator\Validator\ResultType;

--- a/tests/src/Validator/SchemaValidatorTest.php
+++ b/tests/src/Validator/SchemaValidatorTest.php
@@ -2,8 +2,28 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Validator;
 
+use Exception;
 use MoveElevator\ComposerTranslationValidator\Parser\ParserInterface;
 use MoveElevator\ComposerTranslationValidator\Validator\XliffSchemaValidator;
 use PHPUnit\Framework\TestCase;
@@ -145,7 +165,7 @@ EOT
                 ],
             ],
             'XliffParser',
-            'SchemaValidator'
+            'SchemaValidator',
         );
 
         $result = $validator->formatIssueMessage($issue);
@@ -173,7 +193,7 @@ EOT
                 ],
             ],
             'XliffParser',
-            'SchemaValidator'
+            'SchemaValidator',
         );
 
         $result = $validator->formatIssueMessage($issue);
@@ -206,7 +226,7 @@ EOT
                 ],
             ],
             'XliffParser',
-            'SchemaValidator'
+            'SchemaValidator',
         );
 
         $result = $validator->formatIssueMessage($issue);
@@ -228,7 +248,7 @@ EOT
             'test.xlf',
             [],
             'XliffParser',
-            'SchemaValidator'
+            'SchemaValidator',
         );
 
         $result = $validator->formatIssueMessage($issue);
@@ -308,7 +328,7 @@ EOT
                 }
 
                 // Simulate exception with unsupported version message
-                $e = new \Exception('No support implemented for loading XLIFF version 2.0');
+                $e = new Exception('No support implemented for loading XLIFF version 2.0');
                 if (str_contains($e->getMessage(), 'No support implemented for loading XLIFF version')) {
                     $this->logger?->notice(sprintf('Skipping %s: %s', $this->getShortName(), $e->getMessage()));
                 } else {
@@ -352,7 +372,7 @@ EOT
                 }
 
                 // Simulate general validation exception
-                $e = new \Exception('XML parsing error occurred');
+                $e = new Exception('XML parsing error occurred');
                 if (str_contains($e->getMessage(), 'No support implemented for loading XLIFF version')) {
                     $this->logger?->notice(sprintf('Skipping %s: %s', $this->getShortName(), $e->getMessage()));
                 } else {

--- a/tests/src/Validator/ValidatorInterfaceTest.php
+++ b/tests/src/Validator/ValidatorInterfaceTest.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Validator;
 
 use MoveElevator\ComposerTranslationValidator\FileDetector\FileSet;

--- a/tests/src/Validator/ValidatorRegistryTest.php
+++ b/tests/src/Validator/ValidatorRegistryTest.php
@@ -2,6 +2,25 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace MoveElevator\ComposerTranslationValidator\Tests\Validator;
 
 use MoveElevator\ComposerTranslationValidator\Validator\DuplicateKeysValidator;
@@ -44,7 +63,7 @@ final class ValidatorRegistryTest extends TestCase
             $this->assertContains(
                 \MoveElevator\ComposerTranslationValidator\Validator\ValidatorInterface::class,
                 class_implements($validator) ?: [],
-                "Class {$validator} should implement ValidatorInterface"
+                "Class {$validator} should implement ValidatorInterface",
             );
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added GPLv3 license headers to all source, test, and fixture files for improved legal compliance and clarity.
  * Updated code style for constructors and method bodies to use concise empty body syntax where applicable.
  * Standardized import and usage of exception classes for consistency.
  * Added a repository-wide code ownership file assigning all files to a specific maintainer.
  * Switched PHP code style configuration to a new package and updated related development dependencies.

* **Style**
  * Applied minor formatting improvements, such as adding trailing commas and adjusting whitespace, to enhance code readability and maintain consistency.

* **Documentation**
  * Updated file headers and docblocks to reflect licensing and copyright information.

* **Tests**
  * Updated test files to align with new code style and import conventions; no changes to test logic or coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->