### PR TITLE
fix: adjust version constraint for justinrainbow/json-schema in composer files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		"ext-mbstring": "*",
 		"ext-simplexml": "*",
 		"composer-plugin-api": "^1.0 || ^2.0",
-		"justinrainbow/json-schema": "^6.4",
+		"justinrainbow/json-schema": "^5.3 || ^6.4",
 		"psr/log": "^1.0 || ^2.0 || ^3.0",
 		"symfony/config": "^5.0 || ^6.0 || ^7.0",
 		"symfony/console": "^5.0 || ^6.0 || ^7.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ff37c1c799b0af8f3290d09a9201b5b3",
+    "content-hash": "3031be4c578a0b53f4a362f071b385f1",
     "packages": [
         {
             "name": "justinrainbow/json-schema",


### PR DESCRIPTION
This PR adds support for justinrainbow/json-schema ^5.3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded compatibility for a key dependency to support additional versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->