### PR TITLE
fix: improve key naming convention detection for dot notation

### DIFF
--- a/src/Command/ValidateTranslationCommand.php
+++ b/src/Command/ValidateTranslationCommand.php
@@ -218,7 +218,7 @@ HELP
         $format = FormatType::tryFrom($input->getOption('format') ?: $config->getFormat());
 
         if (null === $format) {
-            $this->io?->error('Invalid output format specified. Use "cli" or "json".');
+            $this->io?->error('Invalid output format specified. Use "cli", "json" or "github".');
 
             return Command::FAILURE;
         }
@@ -238,6 +238,9 @@ HELP
         ))->summarize();
     }
 
+    /**
+     * @throws JsonException
+     */
     private function loadConfiguration(InputInterface $input): TranslationValidatorConfig
     {
         $configReader = new ConfigReader();

--- a/src/Config/ConfigReader.php
+++ b/src/Config/ConfigReader.php
@@ -46,6 +46,9 @@ class ConfigReader
         return $this->fileReader->readAsConfig($configPath);
     }
 
+    /**
+     * @throws JsonException
+     */
     public function autoDetect(?string $workingDirectory = null): ?TranslationValidatorConfig
     {
         $workingDirectory ??= getcwd();

--- a/src/Validator/KeyNamingConventionValidator.php
+++ b/src/Validator/KeyNamingConventionValidator.php
@@ -38,6 +38,7 @@ class KeyNamingConventionValidator extends AbstractValidator implements Validato
     private ?KeyNamingConvention $convention = null;
     private ?string $customPattern = null;
     private ?TranslationValidatorConfig $config = null;
+    private bool $configHintShown = false;
 
     public function setConfig(?TranslationValidatorConfig $config): void
     {
@@ -47,6 +48,9 @@ class KeyNamingConventionValidator extends AbstractValidator implements Validato
 
     public function processFile(ParserInterface $file): array
     {
+        // Reset hint shown flag for each new file
+        $this->configHintShown = false;
+
         $keys = $file->extractKeys();
 
         if (null === $keys) {
@@ -118,6 +122,10 @@ class KeyNamingConventionValidator extends AbstractValidator implements Validato
 
     public function setConvention(string $convention): void
     {
+        if ('dot.notation' === $convention) {
+            throw new InvalidArgumentException('dot.notation cannot be configured explicitly. It is used internally for detection but should not be set as a configuration option.');
+        }
+
         $this->convention = KeyNamingConvention::fromString($convention);
     }
 
@@ -184,7 +192,7 @@ class KeyNamingConventionValidator extends AbstractValidator implements Validato
         }
 
         if (str_contains($key, '.')) {
-            return $this->convertDotSeparatedKey($key);
+            return $this->convertDotSeparatedKey($key, $this->convention);
         }
 
         return match ($this->convention) {
@@ -266,23 +274,47 @@ class KeyNamingConventionValidator extends AbstractValidator implements Validato
         return strtolower($result);
     }
 
-    private function convertDotSeparatedKey(string $key): string
+    private function convertDotSeparatedKey(string $key, ?KeyNamingConvention $convention): string
     {
+        if (null === $convention) {
+            return $key;
+        }
+
         $segments = explode('.', $key);
         $convertedSegments = [];
 
         foreach ($segments as $segment) {
-            $convertedSegments[] = match ($this->convention) {
+            $convertedSegments[] = match ($convention) {
                 KeyNamingConvention::SNAKE_CASE => $this->toSnakeCase($segment),
                 KeyNamingConvention::CAMEL_CASE => $this->toCamelCase($segment),
                 KeyNamingConvention::KEBAB_CASE => $this->toKebabCase($segment),
                 KeyNamingConvention::PASCAL_CASE => $this->toPascalCase($segment),
                 KeyNamingConvention::DOT_NOTATION => $this->toDotNotation($segment),
-                null => $segment,
             };
         }
 
         return implode('.', $convertedSegments);
+    }
+
+    /**
+     * Check if the validator is in auto-detection mode (no explicit configuration).
+     */
+    private function isAutoDetectionMode(): bool
+    {
+        return null === $this->convention && null === $this->customPattern;
+    }
+
+    /**
+     * Get a helpful configuration hint for users.
+     */
+    private function getConfigurationHint(): string
+    {
+        // Use only configurable conventions (excludes dot.notation)
+        $availableConventions = KeyNamingConvention::getConfigurableConventions();
+        $conventionsList = implode(', ', $availableConventions);
+
+        return "\n  Tip: Configure a specific naming convention in a configuration file to avoid inconsistencies. "
+            ."Available conventions: {$conventionsList}. ";
     }
 
     public function formatIssueMessage(Issue $issue, string $prefix = ''): string
@@ -299,24 +331,60 @@ class KeyNamingConventionValidator extends AbstractValidator implements Validato
         if (isset($details['inconsistency_type']) && 'mixed_conventions' === $details['inconsistency_type']) {
             $detectedConventions = $details['detected_conventions'] ?? [];
             $dominantConvention = $details['dominant_convention'] ?? 'unknown';
-            $allConventions = $details['all_conventions_found'] ?? [];
 
             $detectedStr = implode(', ', $detectedConventions);
-            $allStr = implode(', ', $allConventions);
 
-            $message = "inconsistent key naming: `{$key}` follows {$detectedStr} but file uses mixed conventions ({$allStr}). Dominant convention: {$dominantConvention}";
+            $message = "key naming inconsistency: `{$key}` uses {$detectedStr} convention";
+            $message .= ", but this file predominantly uses {$dominantConvention}";
+
+            if ('unknown' !== $dominantConvention && 'mixed_conventions' !== $dominantConvention) {
+                $suggestion = $this->suggestKeyConversion($key, $dominantConvention);
+                if ($suggestion !== $key) {
+                    $message .= ". Consider: `{$suggestion}`";
+                }
+            } else {
+                $message .= '. Consider standardizing all keys to use the same naming convention';
+            }
+
+            if ($this->isAutoDetectionMode() && !$this->configHintShown) {
+                $message .= $this->getConfigurationHint();
+                $this->configHintShown = true;
+            }
         } else {
-            // Legacy behavior for configured conventions
             $convention = $details['expected_convention'] ?? 'custom pattern';
             $suggestion = $details['suggestion'] ?? '';
 
-            $message = "key naming convention violation: `{$key}` does not follow {$convention} convention";
+            $message = "key naming convention violation: `{$key}` does not follow the configured {$convention} convention";
             if (!empty($suggestion) && $suggestion !== $key) {
-                $message .= " (suggestion: `{$suggestion}`)";
+                $message .= ". Suggested: `{$suggestion}`";
             }
         }
 
         return "- <fg={$color}>{$level}</> {$prefix}{$message}";
+    }
+
+    /**
+     * Suggest a key conversion to match the dominant convention.
+     */
+    private function suggestKeyConversion(string $key, string $targetConvention): string
+    {
+        try {
+            $convention = KeyNamingConvention::fromString($targetConvention);
+
+            if (str_contains($key, '.')) {
+                return $this->convertDotSeparatedKey($key, $convention);
+            }
+
+            return match ($convention) {
+                KeyNamingConvention::SNAKE_CASE => $this->toSnakeCase($key),
+                KeyNamingConvention::CAMEL_CASE => $this->toCamelCase($key),
+                KeyNamingConvention::KEBAB_CASE => $this->toKebabCase($key),
+                KeyNamingConvention::PASCAL_CASE => $this->toPascalCase($key),
+                KeyNamingConvention::DOT_NOTATION => $this->toDotNotation($key),
+            };
+        } catch (InvalidArgumentException) {
+            return $key;
+        }
     }
 
     /**
@@ -332,11 +400,6 @@ class KeyNamingConventionValidator extends AbstractValidator implements Validato
         return ResultType::WARNING;
     }
 
-    public function shouldShowDetailedOutput(): bool
-    {
-        return false;
-    }
-
     /**
      * Get available naming conventions.
      *
@@ -346,6 +409,11 @@ class KeyNamingConventionValidator extends AbstractValidator implements Validato
     {
         $conventions = [];
         foreach (KeyNamingConvention::cases() as $convention) {
+            // Exclude dot.notation from configurable conventions
+            if ('dot.notation' === $convention->value) {
+                continue;
+            }
+
             $conventions[$convention->value] = [
                 'pattern' => $convention->getPattern(),
                 'description' => $convention->getDescription(),

--- a/tests/src/Validator/KeyNamingConventionValidatorTest.php
+++ b/tests/src/Validator/KeyNamingConventionValidatorTest.php
@@ -114,6 +114,108 @@ final class KeyNamingConventionValidatorTest extends TestCase
         $this->assertEmpty($result);
     }
 
+    public function testConfigurationHintInAutoDetectionMode(): void
+    {
+        // Test that configuration hint is shown when no explicit convention is configured
+        $validator = new KeyNamingConventionValidator();
+
+        $issueData = [
+            'key' => 'testKey',
+            'file' => 'test.yaml',
+            'detected_conventions' => ['camelCase'],
+            'dominant_convention' => 'snake_case',
+            'all_conventions_found' => ['camelCase', 'snake_case'],
+            'inconsistency_type' => 'mixed_conventions',
+        ];
+
+        $issue = new Issue(
+            $issueData['file'],
+            $issueData,
+            'TestParser',
+            'KeyNamingConventionValidator',
+        );
+
+        $message = $validator->formatIssueMessage($issue);
+
+        // Should contain the configuration hint
+        $this->assertStringContainsString('Tip:', $message);
+        $this->assertStringContainsString('Configure a specific naming convention', $message);
+        $this->assertStringContainsString('snake_case, camelCase, kebab-case, PascalCase', $message);
+        $this->assertStringNotContainsString('dot.notation', $message);
+    }
+
+    public function testConfigurationHintShownOnlyOnce(): void
+    {
+        // Test that configuration hint appears only once even with multiple issues
+        $parser = $this->createMock(ParserInterface::class);
+        $parser->method('extractKeys')->willReturn(['someKey', 'another_key', 'thirdKey']);
+        $parser->method('getFileName')->willReturn('test.yaml');
+
+        $validator = new KeyNamingConventionValidator();
+        // No convention set - should be in auto-detection mode
+        $result = $validator->processFile($parser);
+
+        // Should have multiple issues (mixed conventions)
+        $this->assertNotEmpty($result);
+
+        // Format all issue messages
+        $allMessages = [];
+        foreach ($result as $issueData) {
+            $issue = new Issue(
+                $issueData['file'],
+                $issueData,
+                'TestParser',
+                'KeyNamingConventionValidator',
+            );
+            $allMessages[] = $validator->formatIssueMessage($issue);
+        }
+
+        // Count how many times the configuration hint appears
+        $hintCount = 0;
+        foreach ($allMessages as $message) {
+            if (str_contains($message, 'Tip:')) {
+                ++$hintCount;
+            }
+        }
+
+        // Should appear exactly once
+        $this->assertSame(1, $hintCount, 'Configuration hint should appear exactly once');
+
+        // Also verify dot.notation is not in any hint
+        $combinedMessages = implode(' ', $allMessages);
+        if (str_contains($combinedMessages, 'Tip:')) {
+            $this->assertStringNotContainsString('dot.notation', $combinedMessages);
+        }
+    }
+
+    public function testNoConfigurationHintWithExplicitConvention(): void
+    {
+        // Test that no configuration hint is shown when explicit convention is configured
+        $validator = new KeyNamingConventionValidator();
+        $validator->setConvention('snake_case');
+
+        $issueData = [
+            'key' => 'testKey',
+            'file' => 'test.yaml',
+            'expected_convention' => 'snake_case',
+            'pattern' => '/^[a-z]([a-z0-9]|_[a-z0-9])*$/',
+            'suggestion' => 'test_key',
+        ];
+
+        $issue = new Issue(
+            $issueData['file'],
+            $issueData,
+            'TestParser',
+            'KeyNamingConventionValidator',
+        );
+
+        $message = $validator->formatIssueMessage($issue);
+
+        // Should NOT contain the configuration hint
+        $this->assertStringNotContainsString('💡 Tip:', $message);
+        $this->assertStringNotContainsString('translation-validator.yaml', $message);
+    }
+
     public function testProcessFileWithoutConventionConfigured(): void
     {
         $parser = $this->createMock(ParserInterface::class);
@@ -161,6 +263,15 @@ final class KeyNamingConventionValidatorTest extends TestCase
 
         $validator = new KeyNamingConventionValidator();
         $validator->setConvention('invalid_convention');
+    }
+
+    public function testSetConventionWithDotNotationThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('dot.notation cannot be configured explicitly');
+
+        $validator = new KeyNamingConventionValidator();
+        $validator->setConvention('dot.notation');
     }
 
     public function testSetCustomPatternWithValidPattern(): void
@@ -386,6 +497,213 @@ final class KeyNamingConventionValidatorTest extends TestCase
         $validator2 = new KeyNamingConventionValidator();
         $validator2->setCustomPattern('/^[a-z]+$/');
         $this->assertTrue($validator2->shouldRun());
+    }
+
+    public function testEnumGetConfigurableConventions(): void
+    {
+        $configurableConventions = \MoveElevator\ComposerTranslationValidator\Enum\KeyNamingConvention::getConfigurableConventions();
+
+        // Should contain all conventions except dot.notation
+        $this->assertContains('snake_case', $configurableConventions);
+        $this->assertContains('camelCase', $configurableConventions);
+        $this->assertContains('kebab-case', $configurableConventions);
+        $this->assertContains('PascalCase', $configurableConventions);
+        $this->assertNotContains('dot.notation', $configurableConventions);
+
+        // Should have 4 conventions (all except dot.notation)
+        $this->assertCount(4, $configurableConventions);
+    }
+
+    public function testEnumFromStringRejectsDotNotation(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Convention "dot.notation" is not configurable. Available conventions: snake_case, camelCase, kebab-case, PascalCase');
+
+        \MoveElevator\ComposerTranslationValidator\Enum\KeyNamingConvention::fromString('dot.notation');
+    }
+
+    public function testToDotNotationConversion(): void
+    {
+        $validator = new KeyNamingConventionValidator();
+
+        $reflection = new ReflectionClass($validator);
+        $toDotNotationMethod = $reflection->getMethod('toDotNotation');
+        $toDotNotationMethod->setAccessible(true);
+
+        // Test various conversions to dot notation
+        $this->assertEquals('user.name', $toDotNotationMethod->invoke($validator, 'userName'));
+        $this->assertEquals('user.name', $toDotNotationMethod->invoke($validator, 'user_name'));
+        $this->assertEquals('user.name', $toDotNotationMethod->invoke($validator, 'user-name'));
+        $this->assertEquals('xmlhttp.request', $toDotNotationMethod->invoke($validator, 'XMLHttpRequest'));
+        $this->assertEquals('user.profile.settings', $toDotNotationMethod->invoke($validator, 'userProfileSettings'));
+    }
+
+    public function testConvertDotSeparatedKeyWithNullConvention(): void
+    {
+        $validator = new KeyNamingConventionValidator();
+
+        $reflection = new ReflectionClass($validator);
+        $convertMethod = $reflection->getMethod('convertDotSeparatedKey');
+        $convertMethod->setAccessible(true);
+
+        // Should return original key when convention is null
+        $result = $convertMethod->invoke($validator, 'user.profile', null);
+        $this->assertEquals('user.profile', $result);
+    }
+
+    public function testConvertDotSeparatedKeyWithDotNotationEnum(): void
+    {
+        $validator = new KeyNamingConventionValidator();
+
+        $reflection = new ReflectionClass($validator);
+        $convertMethod = $reflection->getMethod('convertDotSeparatedKey');
+        $convertMethod->setAccessible(true);
+
+        // Use the DOT_NOTATION enum directly
+        $dotNotationEnum = \MoveElevator\ComposerTranslationValidator\Enum\KeyNamingConvention::DOT_NOTATION;
+
+        $result = $convertMethod->invoke($validator, 'user.profileSettings', $dotNotationEnum);
+        $this->assertEquals('user.profile.settings', $result);
+    }
+
+    public function testAnalyzeKeyConsistencyWithEmptyKeys(): void
+    {
+        $parser = $this->createMock(ParserInterface::class);
+        $parser->method('extractKeys')->willReturn([]);
+        $parser->method('getFileName')->willReturn('test.yaml');
+
+        $validator = new KeyNamingConventionValidator();
+        $result = $validator->processFile($parser);
+
+        // Should return empty array for empty keys
+        $this->assertEmpty($result);
+    }
+
+    public function testSuggestKeyConversionWithInvalidConvention(): void
+    {
+        $validator = new KeyNamingConventionValidator();
+
+        $reflection = new ReflectionClass($validator);
+        $suggestMethod = $reflection->getMethod('suggestKeyConversion');
+        $suggestMethod->setAccessible(true);
+
+        // Test with invalid convention string that would throw exception
+        $result = $suggestMethod->invoke($validator, 'testKey', 'invalid_convention');
+        $this->assertEquals('testKey', $result); // Should return original key on exception
+    }
+
+    public function testDetectKeyConventionsReturnsMixedConventions(): void
+    {
+        $validator = new KeyNamingConventionValidator();
+
+        $reflection = new ReflectionClass($validator);
+        $detectMethod = $reflection->getMethod('detectKeyConventions');
+        $detectMethod->setAccessible(true);
+
+        // Test with a key that has dots but no matching conventions
+        $result = $detectMethod->invoke($validator, '$pecial.ch@rs.123');
+        $this->assertContains('mixed_conventions', $result);
+    }
+
+    public function testConfigurationLoadingWithInvalidConvention(): void
+    {
+        $config = $this->createMock(\MoveElevator\ComposerTranslationValidator\Config\TranslationValidatorConfig::class);
+        $config->method('getValidatorSettings')
+            ->with('KeyNamingConventionValidator')
+            ->willReturn(['convention' => 'invalid_convention']);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('warning')
+            ->with($this->stringContains('Invalid convention in config'));
+
+        $validator = new KeyNamingConventionValidator($logger);
+        $validator->setConfig($config);
+    }
+
+    public function testConfigurationLoadingWithInvalidCustomPattern(): void
+    {
+        $config = $this->createMock(\MoveElevator\ComposerTranslationValidator\Config\TranslationValidatorConfig::class);
+        $config->method('getValidatorSettings')
+            ->with('KeyNamingConventionValidator')
+            ->willReturn(['custom_pattern' => 'invalid[pattern']);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('warning')
+            ->with($this->stringContains('Invalid custom pattern in config'));
+
+        $validator = new KeyNamingConventionValidator($logger);
+        $validator->setConfig($config);
+    }
+
+    public function testValidateSegmentWithNullConventionReflection(): void
+    {
+        $validator = new KeyNamingConventionValidator();
+
+        $reflection = new ReflectionClass($validator);
+        $validateSegmentMethod = $reflection->getMethod('validateSegment');
+        $validateSegmentMethod->setAccessible(true);
+
+        // With no convention set, should return true for any segment
+        $result = $validateSegmentMethod->invoke($validator, 'anySegment');
+        $this->assertTrue($result);
+    }
+
+    public function testToCamelCaseHandlesPregSplitFailure(): void
+    {
+        $validator = new KeyNamingConventionValidator();
+
+        $reflection = new ReflectionClass($validator);
+        $toCamelCaseMethod = $reflection->getMethod('toCamelCase');
+        $toCamelCaseMethod->setAccessible(true);
+
+        // Test with various edge cases that might affect preg_split
+        $result = $toCamelCaseMethod->invoke($validator, '');
+        $this->assertEquals('', $result);
+
+        $result = $toCamelCaseMethod->invoke($validator, 'single');
+        $this->assertEquals('single', $result);
+    }
+
+    public function testValidateKeyFormatReturnsTrue(): void
+    {
+        $validator = new KeyNamingConventionValidator();
+
+        $reflection = new ReflectionClass($validator);
+        $validateKeyFormatMethod = $reflection->getMethod('validateKeyFormat');
+        $validateKeyFormatMethod->setAccessible(true);
+
+        // With no convention and no custom pattern, should return true
+        $result = $validateKeyFormatMethod->invoke($validator, 'anyKey');
+        $this->assertTrue($result);
+    }
+
+    public function testDetectSegmentConventionsWithUnknownPattern(): void
+    {
+        $validator = new KeyNamingConventionValidator();
+
+        $reflection = new ReflectionClass($validator);
+        $detectSegmentMethod = $reflection->getMethod('detectSegmentConventions');
+        $detectSegmentMethod->setAccessible(true);
+
+        // Test with a segment that matches no convention
+        $result = $detectSegmentMethod->invoke($validator, '$pecial@chars123');
+        $this->assertContains('unknown', $result);
+    }
+
+    public function testMixedConventionsInDominantConventionLogic(): void
+    {
+        $parser = $this->createMock(ParserInterface::class);
+        $parser->method('extractKeys')->willReturn(['valid_key', '$invalid@key', 'another_valid']);
+        $parser->method('getFileName')->willReturn('test.yaml');
+
+        $validator = new KeyNamingConventionValidator();
+        $result = $validator->processFile($parser);
+
+        // Should detect mixed conventions and handle unknown patterns
+        $this->assertNotEmpty($result);
+        $this->assertEquals('mixed_conventions', $result[0]['inconsistency_type']);
     }
 
     #[DataProvider('conversionProvider')]
@@ -628,7 +946,7 @@ final class KeyNamingConventionValidatorTest extends TestCase
         $message = $validator->formatIssueMessage($issue, 'test: ');
 
         $this->assertStringContainsString('Warning', $message);
-        $this->assertStringContainsString('test: inconsistent key naming', $message);
+        $this->assertStringContainsString('test: key naming inconsistency', $message);
         $this->assertStringContainsString('invalidKey', $message);
         $this->assertStringContainsString('camelCase', $message);
         $this->assertStringContainsString('snake_case', $message);
@@ -638,52 +956,15 @@ final class KeyNamingConventionValidatorTest extends TestCase
     {
         $conventions = KeyNamingConventionValidator::getAvailableConventions();
 
-        // Test that all conventions are available including dot notation
+        // Test that configurable conventions are available (excluding dot.notation)
         $this->assertArrayHasKey('camelCase', $conventions);
         $this->assertArrayHasKey('snake_case', $conventions);
         $this->assertArrayHasKey('kebab-case', $conventions);
         $this->assertArrayHasKey('PascalCase', $conventions);
-        $this->assertArrayHasKey('dot.notation', $conventions);
+        $this->assertArrayNotHasKey('dot.notation', $conventions);
 
         // Test descriptions
         $this->assertStringContainsString('camelCase', $conventions['camelCase']['description']);
-        $this->assertStringContainsString('dot.notation', $conventions['dot.notation']['description']);
-    }
-
-    public function testDotNotationValidation(): void
-    {
-        $parser = $this->createMock(ParserInterface::class);
-        $parser->method('extractKeys')->willReturn(['user.name', 'user.email', 'invalid_key']);
-        $parser->method('getFileName')->willReturn('test.yaml');
-
-        $validator = new KeyNamingConventionValidator();
-        $validator->setConvention('dot.notation');
-        $result = $validator->processFile($parser);
-
-        // Should detect invalid_key as violation
-        $this->assertCount(1, $result);
-        $this->assertEquals('invalid_key', $result[0]['key']);
-        // expected_convention is now a string value from enum
-        $this->assertEquals('dot.notation', $result[0]['expected_convention']);
-    }
-
-    public function testDotNotationConversion(): void
-    {
-        $parser = $this->createMock(ParserInterface::class);
-        $parser->method('extractKeys')->willReturn(['userProfile', 'api_endpoint', 'HTTP-Header']);
-        $parser->method('getFileName')->willReturn('test.yaml');
-
-        $validator = new KeyNamingConventionValidator();
-        $validator->setConvention('dot.notation');
-        $result = $validator->processFile($parser);
-
-        $this->assertCount(3, $result);
-
-        // Test suggestions for different input formats
-        $suggestions = array_column($result, 'suggestion');
-        $this->assertContains('user.profile', $suggestions); // camelCase -> dot.notation
-        $this->assertContains('api.endpoint', $suggestions); // snake_case -> dot.notation
-        $this->assertContains('http.header', $suggestions); // kebab-case -> dot.notation
     }
 
     public function testValidateSegmentWithNullConvention(): void


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of key naming conventions to correctly distinguish between camelCase keys with dots and true dot.notation keys.
  * Prevented setting dot.notation as a configurable convention, enhancing validation accuracy.

* **New Features**
  * Enhanced user guidance with clearer messages and configuration hints during key naming validation.
  * Added suggestions for correcting key formats based on detected naming conventions.
  * Expanded supported output formats to include "github" in validation command.

* **Tests**
  * Added extensive tests covering key naming detection, configuration hints, and exception handling for invalid conventions.
  * Verified that dot.notation is excluded from configurable conventions and that related exceptions are properly thrown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->