### PR TITLE
feat[!!!]: update validation result type from WARNING to ERROR

### DIFF
--- a/docs/validators.md
+++ b/docs/validators.md
@@ -380,7 +380,7 @@ validator-settings:
 
 The breadfinder! Catches translation keys that exist in some language files but are missing from others.
 
-**Result:** ![Warning](https://img.shields.io/badge/WARNING-yellow)
+**Result:** ![Error](https://img.shields.io/badge/ERROR-red)
 
 ### Example
 

--- a/src/Validator/MismatchValidator.php
+++ b/src/Validator/MismatchValidator.php
@@ -245,11 +245,6 @@ class MismatchValidator extends AbstractValidator implements ValidatorInterface
         $this->keyArray = [];
     }
 
-    public function resultTypeOnValidationFailure(): ResultType
-    {
-        return ResultType::WARNING;
-    }
-
     public function shouldShowDetailedOutput(): bool
     {
         return true;

--- a/tests/src/Validator/MismatchValidatorTest.php
+++ b/tests/src/Validator/MismatchValidatorTest.php
@@ -312,10 +312,10 @@ final class MismatchValidatorTest extends TestCase
 
         $result = $validator->formatIssueMessage($issue);
 
-        $this->assertStringContainsString('Warning', $result);
+        $this->assertStringContainsString('Error', $result);
         $this->assertStringContainsString('test_key', $result);
         $this->assertStringContainsString('files', $result);
-        $this->assertStringContainsString('<fg=yellow>', $result);
+        $this->assertStringContainsString('<fg=red>', $result);
     }
 
     public function testGetShortName(): void


### PR DESCRIPTION
If I think about it a little longer, I would classify missing translation entries as errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documentation to show that the MismatchValidator now produces an error (red "ERROR" label) instead of a warning.
* **Tests**
  * Updated tests to expect error severity and red color coding for MismatchValidator issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->