### PR TITLE
feat: add KeyDepthValidator to warn about excessive nesting depth in translation keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The following translation validators are available (and enabled by default):
 | [EncodingValidator](docs/validators.md#encodingvalidator) | Validates UTF-8 encoding and Unicode issues |
 | [HtmlTagValidator](docs/validators.md#htmltagvalidator) | Ensures HTML tag consistency across languages |
 | [KeyCountValidator](docs/validators.md#keycountvalidator) | Warns when files exceed a configurable key count threshold |
+| [KeyDepthValidator](docs/validators.md#keydepthvalidator) | Warns when translation keys have excessive nesting depth |
 | [KeyNamingConventionValidator](docs/validators.md#keynamingconventionvalidator) | Enforces key naming patterns (requires config) |
 | [MismatchValidator](docs/validators.md#mismatchvalidator) | Finds missing translations between files |
 | [PlaceholderConsistencyValidator](docs/validators.md#placeholderconsistencyvalidator) | Validates placeholder patterns |

--- a/docs/validators.md
+++ b/docs/validators.md
@@ -8,6 +8,7 @@ This page provides detailed explanations for each validator available in the Com
 - [EncodingValidator](#encodingvalidator)
 - [HtmlTagValidator](#htmltagvalidator)
 - [KeyCountValidator](#keycountvalidator)
+- [KeyDepthValidator](#keydepthvalidator)
 - [KeyNamingConventionValidator](#keynamingconventionvalidator)
 - [MismatchValidator](#mismatchvalidator)
 - [PlaceholderConsistencyValidator](#placeholderconsistencyvalidator)
@@ -375,6 +376,89 @@ composer validate-translations Fixtures/examples/key-count --only "MoveElevator\
 
 > [!NOTE]
 > Large translation files can become difficult to maintain and navigate. Consider splitting them into smaller, domain-specific files when they grow too large. This validator helps you identify when files might benefit from being split up.
+
+---
+
+## [`KeyDepthValidator`](../src/Validator/KeyDepthValidator.php)
+
+> [!NOTE]
+> New in version **1.2.0** (https://github.com/move-elevator/composer-translation-validator/pull/65)
+
+Warns when translation keys have excessive nesting depth, helping identify overly complex key structures that may be hard to maintain.
+
+**Result:** ![Warning](https://img.shields.io/badge/WARNING-yellow)
+
+> [!TIP]
+> By default, this validator warns when translation keys exceed 8 nesting levels. This threshold can be customized through configuration to fit your project's needs.
+
+### Example
+
+**File: `deeply-nested.en.yaml`**
+```yaml
+# Acceptable nesting levels (within threshold of 8)
+user:
+  profile:
+    settings:
+      privacy:
+        notifications:
+          email:
+            enabled: "Email notifications enabled"  # 7 levels - OK
+
+# Keys that exceed the default threshold of 8 levels
+application:
+  modules:
+    auth:
+      forms:
+        login:
+          validation:
+            rules:
+              password:
+                complexity:
+                  requirements: "Password requirements"  # 11 levels - EXCEEDS
+
+# Mixed separator styles that also exceed threshold
+deep_underscore_separated_key_with_many_parts_test: "Deep key"  # 9 levels - EXCEEDS
+long-hyphen-separated-key-with-many-parts-limit: "Deep key"    # 9 levels - EXCEEDS
+```
+
+#### Console Output
+```
+Fixtures/examples/key-depth/deeply-nested.en.yaml
+
+  KeyDepthValidator
+    - Warning Found 4 translation keys with nesting depth exceeding threshold of 8
+
+[WARNING] Language validation completed with warnings.
+```
+
+### Configuration
+
+You can configure the threshold through your configuration file:
+
+```yaml
+# translation-validator.yaml
+validator-settings:
+  KeyDepthValidator:
+    threshold: 5  # Warn when keys have more than 5 nesting levels
+```
+
+See the [configuration file documentation](config-file.md) for more details.
+
+<details>
+<summary>Test this example locally</summary>
+
+```bash
+# Run the validator using pre-created fixtures (from project root)
+composer validate-translations -d tests Fixtures/examples/key-depth --only "MoveElevator\\ComposerTranslationValidator\\Validator\\KeyDepthValidator" -v
+
+# Test with custom configuration (threshold: 5)
+composer validate-translations -d tests Fixtures/examples/key-depth --only "MoveElevator\\ComposerTranslationValidator\\Validator\\KeyDepthValidator" -v --config Fixtures/examples/key-depth/translation-validator.yaml
+```
+
+</details>
+
+> [!NOTE]
+> Deeply nested translation keys can become difficult to understand and maintain. The validator recognizes multiple separators (`.`, `_`, `-`, `:`) and calculates the maximum depth for keys using mixed separators. Consider flattening your key structure or organizing translations into separate domain-specific files when keys become too deeply nested.
 
 ---
 

--- a/src/Validator/KeyDepthValidator.php
+++ b/src/Validator/KeyDepthValidator.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace MoveElevator\ComposerTranslationValidator\Validator;
+
+use MoveElevator\ComposerTranslationValidator\Config\TranslationValidatorConfig;
+use MoveElevator\ComposerTranslationValidator\Parser\JsonParser;
+use MoveElevator\ComposerTranslationValidator\Parser\ParserInterface;
+use MoveElevator\ComposerTranslationValidator\Parser\PhpParser;
+use MoveElevator\ComposerTranslationValidator\Parser\XliffParser;
+use MoveElevator\ComposerTranslationValidator\Parser\YamlParser;
+use Psr\Log\LoggerInterface;
+
+class KeyDepthValidator extends AbstractValidator implements ValidatorInterface
+{
+    private int $threshold = 8;
+
+    public function __construct(?LoggerInterface $logger = null)
+    {
+        parent::__construct($logger);
+    }
+
+    public function setConfig(?TranslationValidatorConfig $config): void
+    {
+        if ($config && $config->hasValidatorSettings('KeyDepthValidator')) {
+            $settings = $config->getValidatorSettings('KeyDepthValidator');
+            $threshold = $settings['threshold'] ?? 8;
+
+            if (is_numeric($threshold) && (int) $threshold > 0) {
+                $this->threshold = (int) $threshold;
+            }
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function processFile(ParserInterface $file): array
+    {
+        $keys = $file->extractKeys();
+
+        if (null === $keys) {
+            $this->logger?->error(
+                'The source file '.$file->getFileName().' is not valid.',
+            );
+
+            return [];
+        }
+
+        $violatingKeys = [];
+        foreach ($keys as $key) {
+            $depth = $this->calculateKeyDepth($key);
+            if ($depth > $this->threshold) {
+                $violatingKeys[] = [
+                    'key' => $key,
+                    'depth' => $depth,
+                    'threshold' => $this->threshold,
+                ];
+            }
+        }
+
+        if (!empty($violatingKeys)) {
+            return [
+                'message' => sprintf(
+                    'Found %d translation key%s with nesting depth exceeding threshold of %d',
+                    count($violatingKeys),
+                    1 === count($violatingKeys) ? '' : 's',
+                    $this->threshold,
+                ),
+                'violating_keys' => $violatingKeys,
+                'threshold' => $this->threshold,
+            ];
+        }
+
+        return [];
+    }
+
+    public function resultTypeOnValidationFailure(): ResultType
+    {
+        return ResultType::WARNING;
+    }
+
+    /**
+     * @return class-string<ParserInterface>[]
+     */
+    public function supportsParser(): array
+    {
+        return [XliffParser::class, YamlParser::class, JsonParser::class, PhpParser::class];
+    }
+
+    /**
+     * Calculate the nesting depth of a translation key.
+     * Examples:
+     * - "simple" => 1
+     * - "header.title" => 2
+     * - "user.profile.settings.privacy" => 4.
+     */
+    private function calculateKeyDepth(string $key): int
+    {
+        // Handle empty keys
+        if (empty($key)) {
+            return 0;
+        }
+
+        // Count the number of separators + 1
+        // Most common separators in translation keys
+        $separators = ['.', '_', '-', ':'];
+
+        $maxDepth = 1; // At least 1 level for any non-empty key
+
+        foreach ($separators as $separator) {
+            if (str_contains($key, $separator)) {
+                $depth = substr_count($key, $separator) + 1;
+                $maxDepth = max($maxDepth, $depth);
+            }
+        }
+
+        return $maxDepth;
+    }
+}

--- a/src/Validator/ValidatorRegistry.php
+++ b/src/Validator/ValidatorRegistry.php
@@ -39,6 +39,7 @@ class ValidatorRegistry
             HtmlTagValidator::class,
             KeyNamingConventionValidator::class,
             KeyCountValidator::class,
+            KeyDepthValidator::class,
             XliffSchemaValidator::class,
             EncodingValidator::class,
         ];

--- a/tests/Fixtures/examples/README.md
+++ b/tests/Fixtures/examples/README.md
@@ -12,6 +12,7 @@ examples/
 ├── encoding/              # EncodingValidator examples
 ├── html-tags/             # HtmlTagValidator examples
 ├── key-count/             # KeyCountValidator examples
+├── key-depth/             # KeyDepthValidator examples
 ├── key-naming/            # KeyNamingConventionValidator examples
 ├── mismatch/              # MismatchValidator examples
 ├── placeholders/          # PlaceholderConsistencyValidator examples

--- a/tests/Fixtures/examples/key-depth/deeply-nested.en.yaml
+++ b/tests/Fixtures/examples/key-depth/deeply-nested.en.yaml
@@ -1,0 +1,68 @@
+# Example file with deeply nested translation keys to trigger KeyDepthValidator warning
+# This file demonstrates what happens when translation keys become too deeply nested
+
+# Acceptable nesting levels (within threshold of 8)
+app:
+  name: "My Application"
+
+navigation:
+  header:
+    menu:
+      items:
+        home: "Home"
+        about: "About"
+        contact: "Contact"
+
+user:
+  profile:
+    settings:
+      privacy:
+        notifications:
+          email:
+            enabled: "Email notifications enabled"  # 7 levels - OK
+
+# Keys that exceed the default threshold of 8 levels
+application:
+  modules:
+    auth:
+      forms:
+        login:
+          validation:
+            rules:
+              password:
+                complexity:
+                  requirements: "Password must meet complexity requirements"  # 11 levels - EXCEEDS
+
+system:
+  configuration:
+    database:
+      connections:
+        primary:
+          settings:
+            connection:
+              parameters:
+                timeout:
+                  value: "Connection timeout value"  # 11 levels - EXCEEDS
+
+# Mixed separator styles that also exceed threshold
+deep_underscore_separated_key_with_many_parts_that_exceed_threshold_test: "Deep underscore key"  # 9 levels with underscores
+
+long-hyphen-separated-key-with-many-parts-that-exceed-threshold-limit: "Deep hyphen key"  # 9 levels with hyphens
+
+# Reasonable nesting examples
+forms:
+  validation:
+    messages:
+      required: "This field is required"
+      email: "Please enter a valid email"
+
+errors:
+  http:
+    404: "Page not found"
+    500: "Internal server error"
+
+api:
+  responses:
+    success:
+      created: "Resource created successfully"
+      updated: "Resource updated successfully"

--- a/tests/Fixtures/examples/key-depth/translation-validator.yaml
+++ b/tests/Fixtures/examples/key-depth/translation-validator.yaml
@@ -1,0 +1,9 @@
+# Configuration file for KeyDepthValidator example
+# This sets a lower threshold to demonstrate the validator behavior
+
+paths:
+  - .
+
+validator-settings:
+  KeyDepthValidator:
+    threshold: 5  # Lower threshold for demonstration purposes

--- a/tests/src/Validator/KeyDepthValidatorTest.php
+++ b/tests/src/Validator/KeyDepthValidatorTest.php
@@ -1,0 +1,386 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer plugin "composer-translation-validator".
+ *
+ * Copyright (C) 2025 Konrad Michalik <km@move-elevator.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace MoveElevator\ComposerTranslationValidator\Tests\Validator;
+
+use MoveElevator\ComposerTranslationValidator\Config\ConfigFactory;
+use MoveElevator\ComposerTranslationValidator\Parser\ParserInterface;
+use MoveElevator\ComposerTranslationValidator\Validator\KeyDepthValidator;
+use MoveElevator\ComposerTranslationValidator\Validator\ResultType;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionClass;
+
+final class KeyDepthValidatorTest extends TestCase
+{
+    public function testProcessFileWithDeepNesting(): void
+    {
+        // Create keys that exceed the default threshold of 8
+        $keys = [
+            'simple',
+            'header.title',
+            'user.profile.settings.privacy.notifications.email.daily.summary.enabled', // 9 levels
+            'app.modules.auth.forms.login.validation.rules.password.complexity.requirements', // 10 levels
+        ];
+
+        $parser = $this->createMock(ParserInterface::class);
+        $parser->method('extractKeys')->willReturn($keys);
+        $parser->method('getFileName')->willReturn('test.yaml');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('error');
+
+        $validator = new KeyDepthValidator($logger);
+        $result = $validator->processFile($parser);
+
+        $this->assertArrayHasKey('message', $result);
+        $this->assertArrayHasKey('violating_keys', $result);
+        $this->assertArrayHasKey('threshold', $result);
+        $this->assertSame(8, $result['threshold']);
+        $this->assertCount(2, $result['violating_keys']);
+
+        $violatingKeys = $result['violating_keys'];
+        $this->assertSame('user.profile.settings.privacy.notifications.email.daily.summary.enabled', $violatingKeys[0]['key']);
+        $this->assertSame(9, $violatingKeys[0]['depth']);
+        $this->assertSame('app.modules.auth.forms.login.validation.rules.password.complexity.requirements', $violatingKeys[1]['key']);
+        $this->assertSame(10, $violatingKeys[1]['depth']);
+
+        $this->assertStringContainsString('Found 2 translation keys', (string) $result['message']);
+        $this->assertStringContainsString('threshold of 8', (string) $result['message']);
+    }
+
+    public function testProcessFileWithAcceptableNesting(): void
+    {
+        $keys = [
+            'simple',
+            'header.title',
+            'user.profile.name',
+            'app.navigation.menu.items',
+            'forms.validation.rules.required', // 5 levels
+            'settings.appearance.theme.colors.primary.default', // 7 levels
+            'notifications.email.settings.frequency.daily.enabled', // 8 levels - exactly at threshold
+        ];
+
+        $parser = $this->createMock(ParserInterface::class);
+        $parser->method('extractKeys')->willReturn($keys);
+        $parser->method('getFileName')->willReturn('test.yaml');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('error');
+
+        $validator = new KeyDepthValidator($logger);
+        $result = $validator->processFile($parser);
+
+        $this->assertEmpty($result);
+    }
+
+    public function testProcessFileWithDifferentSeparators(): void
+    {
+        $keys = [
+            'underscore_separated_key_with_many_parts_that_exceed_threshold_limit_test', // 9 levels with underscore
+            'hyphen-separated-key-with-many-parts-that-exceed-threshold-limit-test', // 9 levels with hyphen
+            'colon:separated:key:with:many:parts:that:exceed:threshold:limit:test', // 11 levels with colon
+            'mixed.key_with-different:separators.in_one-key', // Should take highest depth
+        ];
+
+        $parser = $this->createMock(ParserInterface::class);
+        $parser->method('extractKeys')->willReturn($keys);
+        $parser->method('getFileName')->willReturn('test.yaml');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $validator = new KeyDepthValidator($logger);
+        $result = $validator->processFile($parser);
+
+        $this->assertArrayHasKey('violating_keys', $result);
+        // Let's check how many keys actually violate the threshold
+        $this->assertGreaterThan(0, count($result['violating_keys']));
+    }
+
+    public function testProcessFileWithInvalidFile(): void
+    {
+        $parser = $this->createMock(ParserInterface::class);
+        $parser->method('extractKeys')->willReturn(null);
+        $parser->method('getFileName')->willReturn('invalid.yaml');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('error')
+            ->with($this->stringContains('The source file invalid.yaml is not valid.'));
+
+        $validator = new KeyDepthValidator($logger);
+        $result = $validator->processFile($parser);
+
+        $this->assertEmpty($result);
+    }
+
+    public function testProcessFileWithEmptyKeys(): void
+    {
+        $parser = $this->createMock(ParserInterface::class);
+        $parser->method('extractKeys')->willReturn([]);
+        $parser->method('getFileName')->willReturn('empty.yaml');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('error');
+
+        $validator = new KeyDepthValidator($logger);
+        $result = $validator->processFile($parser);
+
+        $this->assertEmpty($result);
+    }
+
+    public function testValidatorWithCustomThresholdFromConfig(): void
+    {
+        $factory = new ConfigFactory();
+        $config = $factory->createFromArray(['paths' => ['test/']]);
+        $config->setValidatorSetting('KeyDepthValidator', ['threshold' => 3]);
+
+        $keys = [
+            'simple',
+            'header.title', // 2 levels - OK
+            'user.profile.name', // 3 levels - exactly at threshold
+            'app.navigation.menu.items', // 4 levels - exceeds threshold
+        ];
+
+        $parser = $this->createMock(ParserInterface::class);
+        $parser->method('extractKeys')->willReturn($keys);
+        $parser->method('getFileName')->willReturn('test.yaml');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $validator = new KeyDepthValidator($logger);
+        $validator->setConfig($config);
+        $result = $validator->processFile($parser);
+
+        $this->assertArrayHasKey('violating_keys', $result);
+        $this->assertArrayHasKey('threshold', $result);
+        $this->assertSame(3, $result['threshold']);
+        $this->assertCount(1, $result['violating_keys']);
+        $this->assertSame('app.navigation.menu.items', $result['violating_keys'][0]['key']);
+        $this->assertSame(4, $result['violating_keys'][0]['depth']);
+    }
+
+    public function testValidatorWithCustomThresholdBelowAllKeys(): void
+    {
+        $factory = new ConfigFactory();
+        $config = $factory->createFromArray(['paths' => ['test/']]);
+        $config->setValidatorSetting('KeyDepthValidator', ['threshold' => 10]);
+
+        $keys = [
+            'user.profile.settings.privacy.notifications.email', // 6 levels
+            'app.modules.auth.forms.login.validation.rules', // 7 levels
+        ];
+
+        $parser = $this->createMock(ParserInterface::class);
+        $parser->method('extractKeys')->willReturn($keys);
+        $parser->method('getFileName')->willReturn('test.yaml');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $validator = new KeyDepthValidator($logger);
+        $validator->setConfig($config);
+        $result = $validator->processFile($parser);
+
+        $this->assertEmpty($result);
+    }
+
+    public function testValidatorWithInvalidThresholdInConfig(): void
+    {
+        $factory = new ConfigFactory();
+        $config = $factory->createFromArray(['paths' => ['test/']]);
+        $config->setValidatorSetting('KeyDepthValidator', ['threshold' => 'invalid']);
+
+        $keys = [
+            'very.deep.nested.key.with.many.levels.that.exceed.default.threshold', // 11 levels
+        ];
+
+        $parser = $this->createMock(ParserInterface::class);
+        $parser->method('extractKeys')->willReturn($keys);
+        $parser->method('getFileName')->willReturn('test.yaml');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $validator = new KeyDepthValidator($logger);
+        $validator->setConfig($config);
+        $result = $validator->processFile($parser);
+
+        // Should fall back to default threshold of 8
+        $this->assertArrayHasKey('threshold', $result);
+        $this->assertSame(8, $result['threshold']);
+        $this->assertCount(1, $result['violating_keys']);
+    }
+
+    public function testValidatorWithoutConfig(): void
+    {
+        $keys = [
+            'very.deep.nested.key.with.many.levels.that.exceed.default.threshold', // 11 levels
+        ];
+
+        $parser = $this->createMock(ParserInterface::class);
+        $parser->method('extractKeys')->willReturn($keys);
+        $parser->method('getFileName')->willReturn('test.yaml');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $validator = new KeyDepthValidator($logger);
+        $validator->setConfig(null);
+        $result = $validator->processFile($parser);
+
+        // Should use default threshold of 8
+        $this->assertArrayHasKey('threshold', $result);
+        $this->assertSame(8, $result['threshold']);
+    }
+
+    public function testValidatorWithEmptyValidatorSettings(): void
+    {
+        $factory = new ConfigFactory();
+        $config = $factory->createFromArray(['paths' => ['test/']]);
+        // No validator-specific settings
+
+        $keys = [
+            'very.deep.nested.key.with.many.levels.that.exceed.default.threshold', // 11 levels
+        ];
+
+        $parser = $this->createMock(ParserInterface::class);
+        $parser->method('extractKeys')->willReturn($keys);
+        $parser->method('getFileName')->willReturn('test.yaml');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $validator = new KeyDepthValidator($logger);
+        $validator->setConfig($config);
+        $result = $validator->processFile($parser);
+
+        // Should use default threshold of 8
+        $this->assertArrayHasKey('threshold', $result);
+        $this->assertSame(8, $result['threshold']);
+    }
+
+    public function testSupportsParser(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $validator = new KeyDepthValidator($logger);
+
+        $expectedParsers = [
+            \MoveElevator\ComposerTranslationValidator\Parser\XliffParser::class,
+            \MoveElevator\ComposerTranslationValidator\Parser\YamlParser::class,
+            \MoveElevator\ComposerTranslationValidator\Parser\JsonParser::class,
+            \MoveElevator\ComposerTranslationValidator\Parser\PhpParser::class,
+        ];
+        $this->assertSame($expectedParsers, $validator->supportsParser());
+    }
+
+    public function testGetShortName(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $validator = new KeyDepthValidator($logger);
+
+        $this->assertSame('KeyDepthValidator', $validator->getShortName());
+    }
+
+    public function testResultTypeOnValidationFailure(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $validator = new KeyDepthValidator($logger);
+
+        $this->assertSame(ResultType::WARNING, $validator->resultTypeOnValidationFailure());
+    }
+
+    public function testFormatIssueMessage(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $validator = new KeyDepthValidator($logger);
+
+        $issue = new \MoveElevator\ComposerTranslationValidator\Result\Issue(
+            'test.yaml',
+            [
+                'message' => 'Found 2 translation keys with nesting depth exceeding threshold of 8',
+                'violating_keys' => [
+                    ['key' => 'deep.nested.key.example', 'depth' => 9, 'threshold' => 8],
+                ],
+                'threshold' => 8,
+            ],
+            'YamlParser',
+            'KeyDepthValidator',
+        );
+
+        $result = $validator->formatIssueMessage($issue);
+
+        $this->assertStringContainsString('Warning', $result);
+        $this->assertStringContainsString('<fg=yellow>', $result);
+        $this->assertStringContainsString('Found 2 translation keys', $result);
+        $this->assertStringContainsString('threshold of 8', $result);
+    }
+
+    public function testFormatIssueMessageWithPrefix(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $validator = new KeyDepthValidator($logger);
+
+        $issue = new \MoveElevator\ComposerTranslationValidator\Result\Issue(
+            'test.yaml',
+            [
+                'message' => 'Found 1 translation key with nesting depth exceeding threshold of 5',
+                'violating_keys' => [
+                    ['key' => 'very.deep.nested.key.example.test', 'depth' => 6, 'threshold' => 5],
+                ],
+                'threshold' => 5,
+            ],
+            'YamlParser',
+            'KeyDepthValidator',
+        );
+
+        $result = $validator->formatIssueMessage($issue, 'in file test.yaml: ');
+
+        $this->assertStringContainsString('Warning', $result);
+        $this->assertStringContainsString('in file test.yaml:', $result);
+        $this->assertStringContainsString('Found 1 translation key', $result);
+    }
+
+    public function testCalculateKeyDepthWithDifferentPatterns(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $validator = new KeyDepthValidator($logger);
+
+        // Use reflection to test the private method
+        $reflection = new ReflectionClass($validator);
+        $method = $reflection->getMethod('calculateKeyDepth');
+        $method->setAccessible(true);
+
+        // Test cases
+        $testCases = [
+            ['', 0], // empty key
+            ['simple', 1], // simple key
+            ['header.title', 2], // dot separated
+            ['user.profile.name', 3], // triple dot
+            ['app.modules.auth.forms.login.validation.rules.password', 8], // deep dot nesting
+            ['user_profile_settings', 3], // underscore separated
+            ['header-navigation-menu', 3], // hyphen separated
+            ['app:config:database:host', 4], // colon separated
+            ['app.config.database-host:port:timeout', 3], // mixed separators - 2 dots=3 levels, 1 hyphen=2 levels, 2 colons=3 levels → max is 3
+            ['a', 1], // single character
+            ['verylongkeywithoutseparators', 1], // no separators
+            ['a.b.c.d.e.f.g.h.i.j.k.l.m.n.o', 15], // many dots
+            ['a_b_c_d_e_f_g_h_i_j', 10], // many underscores
+        ];
+
+        foreach ($testCases as [$key, $expectedDepth]) {
+            $actualDepth = $method->invoke($validator, $key);
+            $this->assertSame($expectedDepth, $actualDepth, "Key '$key' should have depth $expectedDepth but got $actualDepth");
+        }
+    }
+}

--- a/tests/src/Validator/ValidatorRegistryTest.php
+++ b/tests/src/Validator/ValidatorRegistryTest.php
@@ -28,6 +28,7 @@ use MoveElevator\ComposerTranslationValidator\Validator\EmptyValuesValidator;
 use MoveElevator\ComposerTranslationValidator\Validator\EncodingValidator;
 use MoveElevator\ComposerTranslationValidator\Validator\HtmlTagValidator;
 use MoveElevator\ComposerTranslationValidator\Validator\KeyCountValidator;
+use MoveElevator\ComposerTranslationValidator\Validator\KeyDepthValidator;
 use MoveElevator\ComposerTranslationValidator\Validator\KeyNamingConventionValidator;
 use MoveElevator\ComposerTranslationValidator\Validator\MismatchValidator;
 use MoveElevator\ComposerTranslationValidator\Validator\PlaceholderConsistencyValidator;
@@ -47,10 +48,11 @@ final class ValidatorRegistryTest extends TestCase
         $this->assertContains(PlaceholderConsistencyValidator::class, $validators);
         $this->assertContains(HtmlTagValidator::class, $validators);
         $this->assertContains(KeyCountValidator::class, $validators);
+        $this->assertContains(KeyDepthValidator::class, $validators);
         $this->assertContains(KeyNamingConventionValidator::class, $validators);
         $this->assertContains(XliffSchemaValidator::class, $validators);
         $this->assertContains(EncodingValidator::class, $validators);
-        $this->assertCount(10, $validators);
+        $this->assertCount(11, $validators);
     }
 
     public function testGetAvailableValidatorsReturnsArray(): void


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new translation key depth validator that warns when translation keys are nested beyond a configurable threshold (default is 8 levels).
  * Validator supports various key separators and can be configured via a settings file.

* **Documentation**
  * Updated documentation to describe the new key depth validator, including usage instructions, configuration options, and example outputs.

* **Tests**
  * Added comprehensive tests and example fixtures to ensure correct detection of deeply nested translation keys and validator configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->