### PR TITLE
feat: add XLIFF 2.x support to XliffParser

### DIFF
--- a/src/Parser/XliffParser.php
+++ b/src/Parser/XliffParser.php
@@ -25,6 +25,7 @@ use SimpleXMLElement;
 class XliffParser extends AbstractParser implements ParserInterface
 {
     private readonly SimpleXMLElement|bool $xml;
+    private readonly bool $isVersion2;
 
     /**
      * @param string $filePath Path to the XLIFF file
@@ -48,6 +49,8 @@ class XliffParser extends AbstractParser implements ParserInterface
             throw new InvalidArgumentException("Failed to parse XML content from file: {$filePath}");
         }
         libxml_clear_errors();
+
+        $this->isVersion2 = version_compare((string) ($this->xml['version'] ?? ''), '2.0', '>=');
     }
 
     /**
@@ -55,8 +58,13 @@ class XliffParser extends AbstractParser implements ParserInterface
      */
     public function extractKeys(): ?array
     {
+        $units = $this->getTranslationUnits();
+        if (null === $units) {
+            return [];
+        }
+
         $keys = [];
-        foreach ($this->xml->file->body->{'trans-unit'} as $unit) {
+        foreach ($units as $unit) {
             $keys[] = (string) $unit['id'];
         }
 
@@ -65,27 +73,29 @@ class XliffParser extends AbstractParser implements ParserInterface
 
     public function getContentByKey(string $key): ?string
     {
+        $units = $this->getTranslationUnits();
+        if (null === $units) {
+            return null;
+        }
+
         $attribute = $this->hasTargetLanguage() ? 'target' : 'source';
 
-        foreach ($this->xml->file->body->{'trans-unit'} as $unit) {
-            if ((string) $unit['id'] === $key) {
-                if ('' !== (string) $unit->{$attribute}) {
-                    return (string) $unit->{$attribute};
-                }
+        foreach ($units as $unit) {
+            if ((string) $unit['id'] !== $key) {
+                continue;
+            }
 
-                if ('target' === $attribute && $this->hasTargetLanguage()) {
-                    $fallbackContent = (string) $unit->source;
-                    if ('' !== $fallbackContent) {
-                        return $fallbackContent;
-                    }
-                }
+            $source = $this->getUnitContent($unit, 'source');
+            $target = $this->getUnitContent($unit, 'target');
 
-                if ('source' === $attribute && !$this->hasTargetLanguage()) {
-                    $fallbackContent = (string) $unit->target;
-                    if ('' !== $fallbackContent) {
-                        return $fallbackContent;
-                    }
-                }
+            $primary = 'target' === $attribute ? $target : $source;
+            if ('' !== $primary) {
+                return $primary;
+            }
+
+            $fallback = 'target' === $attribute ? $source : $target;
+            if ('' !== $fallback) {
+                return $fallback;
             }
         }
 
@@ -107,16 +117,40 @@ class XliffParser extends AbstractParser implements ParserInterface
             $this->getFileName(),
             $matches,
         )) {
-            $language = $matches[1];
-        } else {
-            $language = (string) ($this->xml->file['source-language'] ?? '');
+            return $matches[1];
         }
 
-        return $language;
+        if ($this->isVersion2) {
+            return (string) ($this->xml['srcLang'] ?? '');
+        }
+
+        return (string) ($this->xml->file['source-language'] ?? '');
+    }
+
+    private function getTranslationUnits(): ?SimpleXMLElement
+    {
+        if ($this->isVersion2) {
+            return $this->xml->file->unit;
+        }
+
+        return $this->xml->file->body->{'trans-unit'};
+    }
+
+    private function getUnitContent(SimpleXMLElement $unit, string $element): string
+    {
+        if ($this->isVersion2) {
+            return (string) ($unit->segment->{$element} ?? '');
+        }
+
+        return (string) ($unit->{$element} ?? '');
     }
 
     private function hasTargetLanguage(): bool
     {
+        if ($this->isVersion2) {
+            return !empty((string) ($this->xml['trgLang'] ?? ''));
+        }
+
         return !empty((string) $this->xml->file['target-language']);
     }
 }

--- a/src/Parser/XliffParser.php
+++ b/src/Parser/XliffParser.php
@@ -130,10 +130,14 @@ class XliffParser extends AbstractParser implements ParserInterface
     private function getTranslationUnits(): ?SimpleXMLElement
     {
         if ($this->isVersion2) {
-            return $this->xml->file->unit;
+            $units = $this->xml->file->unit;
+
+            return $units->count() > 0 ? $units : null;
         }
 
-        return $this->xml->file->body->{'trans-unit'};
+        $units = $this->xml->file->body->{'trans-unit'};
+
+        return $units->count() > 0 ? $units : null;
     }
 
     private function getUnitContent(SimpleXMLElement $unit, string $element): string

--- a/tests/src/Parser/XliffParserTest.php
+++ b/tests/src/Parser/XliffParserTest.php
@@ -88,6 +88,57 @@ EOT;
 </xliff>
 EOT;
 
+    private string $xliff2File;
+    private string $xliff2Content = <<<'EOT'
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en">
+  <file id="messages">
+    <unit id="key1">
+      <segment>
+        <source>Source 1</source>
+      </segment>
+    </unit>
+    <unit id="key2">
+      <segment>
+        <source>Source 2</source>
+      </segment>
+    </unit>
+    <unit id="key3">
+      <segment>
+        <source>Source 3</source>
+      </segment>
+    </unit>
+  </file>
+</xliff>
+EOT;
+
+    private string $xliff2TargetFile;
+    private string $xliff2TargetContent = <<<'EOT'
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="de">
+  <file id="messages">
+    <unit id="key1">
+      <segment>
+        <source>Source 1</source>
+        <target>Target 1</target>
+      </segment>
+    </unit>
+    <unit id="key2">
+      <segment>
+        <source>Source 2</source>
+        <target>Target 2</target>
+      </segment>
+    </unit>
+    <unit id="key3">
+      <segment>
+        <source>Source 3</source>
+        <target></target>
+      </segment>
+    </unit>
+  </file>
+</xliff>
+EOT;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -102,6 +153,12 @@ EOT;
 
         $this->targetLanguageXliffFile = $this->tempDir.'/messages.de.xlf';
         file_put_contents($this->targetLanguageXliffFile, $this->targetLanguageXliffContent);
+
+        $this->xliff2File = $this->tempDir.'/messages_v2.xlf';
+        file_put_contents($this->xliff2File, $this->xliff2Content);
+
+        $this->xliff2TargetFile = $this->tempDir.'/messages_v2.de.xlf';
+        file_put_contents($this->xliff2TargetFile, $this->xliff2TargetContent);
     }
 
     protected function tearDown(): void
@@ -318,6 +375,108 @@ EOT;
 
         $parser = new XliffParser($emptyFile);
         $this->assertNull($parser->getContentByKey('empty_both'));
+    }
+
+    public function testExtractKeysXliff2(): void
+    {
+        $parser = new XliffParser($this->xliff2File);
+        $keys = $parser->extractKeys();
+
+        $this->assertSame(['key1', 'key2', 'key3'], $keys);
+    }
+
+    public function testGetContentByKeySourceXliff2(): void
+    {
+        $parser = new XliffParser($this->xliff2File);
+
+        $this->assertSame('Source 1', $parser->getContentByKey('key1'));
+        $this->assertSame('Source 2', $parser->getContentByKey('key2'));
+        $this->assertSame('Source 3', $parser->getContentByKey('key3'));
+        $this->assertNull($parser->getContentByKey('nonexistent_key'));
+    }
+
+    public function testGetContentByKeyWithTargetLanguageXliff2(): void
+    {
+        $parser = new XliffParser($this->xliff2TargetFile);
+
+        $this->assertSame('Target 1', $parser->getContentByKey('key1'));
+        $this->assertSame('Target 2', $parser->getContentByKey('key2'));
+        $this->assertSame('Source 3', $parser->getContentByKey('key3'));
+        $this->assertNull($parser->getContentByKey('nonexistent_key'));
+    }
+
+    public function testGetLanguageFromSrcLangAttributeXliff2(): void
+    {
+        $parser = new XliffParser($this->xliff2File);
+        $this->assertSame('en', $parser->getLanguage());
+    }
+
+    public function testGetContentByKeyFallsBackToSourceWhenTargetIsEmptyXliff2(): void
+    {
+        $fallbackFile = $this->tempDir.'/v2_fallback.xlf';
+        $fallbackContent = <<<'EOT'
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="de">
+  <file id="messages">
+    <unit id="empty_target">
+      <segment>
+        <source>Fallback Source</source>
+        <target></target>
+      </segment>
+    </unit>
+  </file>
+</xliff>
+EOT;
+        file_put_contents($fallbackFile, $fallbackContent);
+
+        $parser = new XliffParser($fallbackFile);
+        $this->assertSame('Fallback Source', $parser->getContentByKey('empty_target'));
+    }
+
+    public function testGetContentByKeyFallsBackToTargetWhenSourceIsEmptyXliff2(): void
+    {
+        $fallbackFile = $this->tempDir.'/v2_source_fallback.xlf';
+        $fallbackContent = <<<'EOT'
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en">
+  <file id="messages">
+    <unit id="empty_source">
+      <segment>
+        <source></source>
+        <target>Fallback Target</target>
+      </segment>
+    </unit>
+  </file>
+</xliff>
+EOT;
+        file_put_contents($fallbackFile, $fallbackContent);
+
+        $parser = new XliffParser($fallbackFile);
+        $this->assertSame('Fallback Target', $parser->getContentByKey('empty_source'));
+    }
+
+    public function testExtractKeysXliff22(): void
+    {
+        $xliff22File = $this->tempDir.'/messages_v22.xlf';
+        $xliff22Content = <<<'EOT'
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.2" srcLang="en" trgLang="de">
+  <file id="messages">
+    <unit id="key1">
+      <segment>
+        <source>Source 1</source>
+        <target>Target 1</target>
+      </segment>
+    </unit>
+  </file>
+</xliff>
+EOT;
+        file_put_contents($xliff22File, $xliff22Content);
+
+        $parser = new XliffParser($xliff22File);
+        $this->assertSame(['key1'], $parser->extractKeys());
+        $this->assertSame('Target 1', $parser->getContentByKey('key1'));
+        $this->assertSame('en', $parser->getLanguage());
     }
 
     private function removeDirectory(string $path): void


### PR DESCRIPTION
Closes #105 

## Summary

- Add XLIFF 2.0/2.1/2.2 parsing support to `XliffParser`
- Handle structural differences between XLIFF 1.2 and 2.x (unit/segment vs trans-unit/body, srcLang/trgLang vs source-language/target-language)
- Version detection via `version_compare()` to cover all 2.x versions

## Changes

- `src/Parser/XliffParser.php` - Detect XLIFF version, delegate to version-specific XML paths for units, content, and language attributes
- `tests/src/Parser/XliffParserTest.php` - Add 7 test cases for XLIFF 2.0 and 2.2 (key extraction, content retrieval, language detection, fallback behavior)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for XLIFF 2.0 and 2.2 parsing, including improved extraction of translation units and content retrieval.
  * Smarter primary-vs-fallback selection when source or target text is missing.

* **Bug Fixes**
  * Handles missing/empty translation units gracefully and improves language detection for XLIFF v2 files.

* **Tests**
  * Expanded test coverage for XLIFF 2.0/2.2 scenarios (key extraction, content selection, and language handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->