### PR TITLE
refactor: replace static ParserCache with constructor injection

### DIFF
--- a/src/Parser/ParserCache.php
+++ b/src/Parser/ParserCache.php
@@ -24,9 +24,9 @@ use function count;
 class ParserCache
 {
     /** @var array<string, ParserInterface> */
-    private static array $cache = [];
+    private array $cache = [];
 
-    public static function get(string $filePath, ?string $parserClass): ParserInterface|false
+    public function get(string $filePath, ?string $parserClass): ParserInterface|false
     {
         if (null === $parserClass) {
             return false;
@@ -34,26 +34,26 @@ class ParserCache
 
         $cacheKey = $filePath.'::'.$parserClass;
 
-        if (!isset(self::$cache[$cacheKey])) {
+        if (!isset($this->cache[$cacheKey])) {
             /** @var ParserInterface $parser */
             $parser = new $parserClass($filePath);
-            self::$cache[$cacheKey] = $parser;
+            $this->cache[$cacheKey] = $parser;
         }
 
-        return self::$cache[$cacheKey];
+        return $this->cache[$cacheKey];
     }
 
-    public static function clear(): void
+    public function clear(): void
     {
-        self::$cache = [];
+        $this->cache = [];
     }
 
     /** @return array<string, mixed> */
-    public static function getCacheStats(): array
+    public function getCacheStats(): array
     {
         return [
-            'cached_parsers' => count(self::$cache),
-            'cache_keys' => array_keys(self::$cache),
+            'cached_parsers' => count($this->cache),
+            'cache_keys' => array_keys($this->cache),
         ];
     }
 }

--- a/src/Result/ValidationRun.php
+++ b/src/Result/ValidationRun.php
@@ -31,14 +31,7 @@ use function is_array;
  */
 class ValidationRun
 {
-    private ParserCache $parserCache;
-
-    public function __construct(
-        private readonly LoggerInterface $logger,
-        ?ParserCache $parserCache = null,
-    ) {
-        $this->parserCache = $parserCache ?? new ParserCache();
-    }
+    public function __construct(private readonly LoggerInterface $logger, private readonly ?ParserCache $parserCache = new ParserCache()) {}
 
     /**
      * @param array<FileSet>                          $fileSets

--- a/src/Result/ValidationRun.php
+++ b/src/Result/ValidationRun.php
@@ -31,9 +31,14 @@ use function is_array;
  */
 class ValidationRun
 {
+    private ParserCache $parserCache;
+
     public function __construct(
         private readonly LoggerInterface $logger,
-    ) {}
+        ?ParserCache $parserCache = null,
+    ) {
+        $this->parserCache = $parserCache ?? new ParserCache();
+    }
 
     /**
      * @param array<FileSet>                          $fileSets
@@ -52,6 +57,11 @@ class ValidationRun
             foreach ($validatorClasses as $validatorClass) {
                 // Create a new validator instance for each FileSet to ensure isolation
                 $validatorInstance = new $validatorClass($this->logger);
+
+                // Share the ParserCache instance across all validators
+                if (method_exists($validatorInstance, 'setParserCache')) {
+                    $validatorInstance->setParserCache($this->parserCache);
+                }
 
                 // Pass config to validator if it supports it
                 if (null !== $config && method_exists($validatorInstance, 'setConfig')) {
@@ -77,7 +87,7 @@ class ValidationRun
         $validatorsRun = count($validatorClasses);
 
         // Get cache statistics before clearing cache
-        $cacheStats = ParserCache::getCacheStats();
+        $cacheStats = $this->parserCache->getCacheStats();
         $parsersCached = $cacheStats['cached_parsers'];
 
         $executionTime = microtime(true) - $startTime;
@@ -90,7 +100,7 @@ class ValidationRun
         );
 
         $validationResult = new ValidationResult($validatorInstances, $overallResult, $validatorFileSetPairs, $statistics);
-        ParserCache::clear();
+        $this->parserCache->clear();
 
         return $validationResult;
     }
@@ -127,7 +137,7 @@ class ValidationRun
 
             foreach ($fileSet->getFiles() as $file) {
                 try {
-                    $parser = ParserCache::get($file, $parserClass);
+                    $parser = $this->parserCache->get($file, $parserClass);
                     if (false === $parser) {
                         continue;
                     }

--- a/src/Result/ValidationRun.php
+++ b/src/Result/ValidationRun.php
@@ -31,14 +31,10 @@ use function is_array;
  */
 class ValidationRun
 {
-    private readonly ParserCache $parserCache;
-
     public function __construct(
         private readonly LoggerInterface $logger,
-        ?ParserCache $parserCache = null,
-    ) {
-        $this->parserCache = $parserCache ?? new ParserCache();
-    }
+        private readonly ParserCache $parserCache = new ParserCache(),
+    ) {}
 
     /**
      * @param array<FileSet>                          $fileSets

--- a/src/Result/ValidationRun.php
+++ b/src/Result/ValidationRun.php
@@ -31,7 +31,14 @@ use function is_array;
  */
 class ValidationRun
 {
-    public function __construct(private readonly LoggerInterface $logger, private readonly ?ParserCache $parserCache = new ParserCache()) {}
+    private readonly ParserCache $parserCache;
+
+    public function __construct(
+        private readonly LoggerInterface $logger,
+        ?ParserCache $parserCache = null,
+    ) {
+        $this->parserCache = $parserCache ?? new ParserCache();
+    }
 
     /**
      * @param array<FileSet>                          $fileSets

--- a/src/Validator/AbstractValidator.php
+++ b/src/Validator/AbstractValidator.php
@@ -36,7 +36,19 @@ abstract class AbstractValidator
 
     protected string $currentFilePath = '';
 
-    public function __construct(protected ?LoggerInterface $logger = null) {}
+    private ParserCache $parserCache;
+
+    public function __construct(
+        protected ?LoggerInterface $logger = null,
+        ?ParserCache $parserCache = null,
+    ) {
+        $this->parserCache = $parserCache ?? new ParserCache();
+    }
+
+    public function setParserCache(ParserCache $parserCache): void
+    {
+        $this->parserCache = $parserCache;
+    }
 
     /**
      * @param string[]                           $files
@@ -60,7 +72,7 @@ abstract class AbstractValidator
         foreach ($files as $filePath) {
             $this->currentFilePath = $filePath;
 
-            $file = ParserCache::get(
+            $file = $this->parserCache->get(
                 $filePath,
                 $parserClass ?: ParserRegistry::resolveParserClass(
                     $filePath,

--- a/src/Validator/AbstractValidator.php
+++ b/src/Validator/AbstractValidator.php
@@ -36,14 +36,10 @@ abstract class AbstractValidator
 
     protected string $currentFilePath = '';
 
-    private ParserCache $parserCache;
-
     public function __construct(
         protected ?LoggerInterface $logger = null,
-        ?ParserCache $parserCache = null,
-    ) {
-        $this->parserCache = $parserCache ?? new ParserCache();
-    }
+        private ParserCache $parserCache = new ParserCache(),
+    ) {}
 
     public function setParserCache(ParserCache $parserCache): void
     {

--- a/tests/src/Parser/ParserCacheTest.php
+++ b/tests/src/Parser/ParserCacheTest.php
@@ -28,10 +28,11 @@ final class ParserCacheTest extends TestCase
 {
     private string $testFile;
 
+    private ParserCache $parserCache;
+
     protected function setUp(): void
     {
-        // Clear cache before each test
-        ParserCache::clear();
+        $this->parserCache = new ParserCache();
 
         // Create a test YAML file
         $this->testFile = tempnam(sys_get_temp_dir(), 'test_').'.yaml';
@@ -44,12 +45,11 @@ final class ParserCacheTest extends TestCase
         if (file_exists($this->testFile)) {
             unlink($this->testFile);
         }
-        ParserCache::clear();
     }
 
     public function testGetCreatesNewParserInstance(): void
     {
-        $parser = ParserCache::get($this->testFile, YamlParser::class);
+        $parser = $this->parserCache->get($this->testFile, YamlParser::class);
         $this->assertNotFalse($parser);
 
         $this->assertInstanceOf(YamlParser::class, $parser);
@@ -58,8 +58,8 @@ final class ParserCacheTest extends TestCase
 
     public function testGetReturnsSameInstanceOnSecondCall(): void
     {
-        $parser1 = ParserCache::get($this->testFile, YamlParser::class);
-        $parser2 = ParserCache::get($this->testFile, YamlParser::class);
+        $parser1 = $this->parserCache->get($this->testFile, YamlParser::class);
+        $parser2 = $this->parserCache->get($this->testFile, YamlParser::class);
 
         $this->assertSame($parser1, $parser2);
     }
@@ -70,8 +70,8 @@ final class ParserCacheTest extends TestCase
         file_put_contents($testFile2, "key3: value3\n");
 
         try {
-            $parser1 = ParserCache::get($this->testFile, YamlParser::class);
-            $parser2 = ParserCache::get($testFile2, YamlParser::class);
+            $parser1 = $this->parserCache->get($this->testFile, YamlParser::class);
+            $parser2 = $this->parserCache->get($testFile2, YamlParser::class);
             $this->assertNotFalse($parser1);
             $this->assertNotFalse($parser2);
 
@@ -102,8 +102,8 @@ final class ParserCacheTest extends TestCase
 </xliff>');
 
         try {
-            $yamlParser = ParserCache::get($this->testFile, YamlParser::class);
-            $xliffParser = ParserCache::get($xliffFile, XliffParser::class);
+            $yamlParser = $this->parserCache->get($this->testFile, YamlParser::class);
+            $xliffParser = $this->parserCache->get($xliffFile, XliffParser::class);
 
             $this->assertNotSame($yamlParser, $xliffParser);
             $this->assertInstanceOf(YamlParser::class, $yamlParser);
@@ -118,30 +118,30 @@ final class ParserCacheTest extends TestCase
     public function testClearEmptiesCache(): void
     {
         // Add something to cache
-        ParserCache::get($this->testFile, YamlParser::class);
+        $this->parserCache->get($this->testFile, YamlParser::class);
 
-        $statsBefore = ParserCache::getCacheStats();
+        $statsBefore = $this->parserCache->getCacheStats();
         $this->assertSame(1, $statsBefore['cached_parsers']);
 
-        ParserCache::clear();
+        $this->parserCache->clear();
 
-        $statsAfter = ParserCache::getCacheStats();
+        $statsAfter = $this->parserCache->getCacheStats();
         $this->assertSame(0, $statsAfter['cached_parsers']);
         $this->assertEmpty($statsAfter['cache_keys']);
     }
 
     public function testGetCacheStatsReturnsCorrectData(): void
     {
-        $stats = ParserCache::getCacheStats();
+        $stats = $this->parserCache->getCacheStats();
         $this->assertArrayHasKey('cached_parsers', $stats);
         $this->assertArrayHasKey('cache_keys', $stats);
         $this->assertSame(0, $stats['cached_parsers']);
         $this->assertEmpty($stats['cache_keys']);
 
         // Add parser to cache
-        ParserCache::get($this->testFile, YamlParser::class);
+        $this->parserCache->get($this->testFile, YamlParser::class);
 
-        $statsAfter = ParserCache::getCacheStats();
+        $statsAfter = $this->parserCache->getCacheStats();
         $this->assertSame(1, $statsAfter['cached_parsers']);
         $this->assertCount(1, $statsAfter['cache_keys']);
         $this->assertStringContainsString($this->testFile, (string) $statsAfter['cache_keys'][0]);
@@ -150,9 +150,9 @@ final class ParserCacheTest extends TestCase
 
     public function testCacheKeyFormat(): void
     {
-        ParserCache::get($this->testFile, YamlParser::class);
+        $this->parserCache->get($this->testFile, YamlParser::class);
 
-        $stats = ParserCache::getCacheStats();
+        $stats = $this->parserCache->getCacheStats();
         $expectedKey = $this->testFile.'::'.YamlParser::class;
 
         $this->assertContains($expectedKey, $stats['cache_keys']);
@@ -160,7 +160,18 @@ final class ParserCacheTest extends TestCase
 
     public function testGetWithNullParserClassReturnsFalse(): void
     {
-        $result = ParserCache::get($this->testFile, null);
+        $result = $this->parserCache->get($this->testFile, null);
         $this->assertFalse($result);
+    }
+
+    public function testSeparateInstancesHaveIndependentCaches(): void
+    {
+        $cache1 = new ParserCache();
+        $cache2 = new ParserCache();
+
+        $cache1->get($this->testFile, YamlParser::class);
+
+        $this->assertSame(1, $cache1->getCacheStats()['cached_parsers']);
+        $this->assertSame(0, $cache2->getCacheStats()['cached_parsers']);
     }
 }


### PR DESCRIPTION
## Summary

- Convert `ParserCache` from static to instance-based class
- Add constructor injection with nullable parameter and sensible defaults to `AbstractValidator` and `ValidationRun`
- Share cache instance via `setParserCache()` setter to ensure validators reuse parsed files
- Improve testability by enabling cache mocking and instance isolation

## Changes

- `src/Parser/ParserCache.php` - Convert static properties/methods to instance-based
- `src/Validator/AbstractValidator.php` - Add `?ParserCache` constructor param and setter
- `src/Result/ValidationRun.php` - Add `?ParserCache` constructor param, inject shared cache into validators
- `tests/src/Parser/ParserCacheTest.php` - Update tests for instance-based behavior, add isolation test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Parser caching moved from a global static cache to instance-level caches, enabling per-run cache isolation and optional sharing of a cache within a validation run or validator.

* **Tests**
  * Test suite updated to exercise instance-based caching and adds a test confirming independent caches between distinct instances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->