### PR TITLE
refactor: extract DistributesIssuesForDisplayTrait from validators

### DIFF
--- a/src/Validator/HtmlTagValidator.php
+++ b/src/Validator/HtmlTagValidator.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace MoveElevator\ComposerTranslationValidator\Validator;
 
-use MoveElevator\ComposerTranslationValidator\FileDetector\FileSet;
 use MoveElevator\ComposerTranslationValidator\Parser\{JsonParser, ParserInterface, PhpParser, XliffParser, YamlParser};
 use MoveElevator\ComposerTranslationValidator\Result\Issue;
+use MoveElevator\ComposerTranslationValidator\Validator\Trait\DistributesIssuesForDisplayTrait;
 use Symfony\Component\Console\Helper\{Table, TableStyle};
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -30,6 +30,8 @@ use function in_array;
  */
 class HtmlTagValidator extends AbstractValidator implements ValidatorInterface
 {
+    use DistributesIssuesForDisplayTrait;
+
     /** @var array<string, array<string, array{value: string, html_structure: array<string, mixed>}>> */
     protected array $keyData = [];
 
@@ -98,32 +100,6 @@ class HtmlTagValidator extends AbstractValidator implements ValidatorInterface
         $inconsistencyText = implode('; ', $inconsistencies);
 
         return "- <fg={$color}>{$level}</> {$prefix}HTML tag inconsistency in translation key `{$key}` - {$inconsistencyText}";
-    }
-
-    public function distributeIssuesForDisplay(FileSet $fileSet): array
-    {
-        $distribution = [];
-
-        foreach ($this->issues as $issue) {
-            $details = $issue->getDetails();
-            $files = $details['files'] ?? [];
-
-            foreach ($files as $filePath => $_) {
-                if (!empty($filePath)) {
-                    $fileSpecificIssue = new Issue(
-                        $filePath,
-                        $details,
-                        $issue->getParser(),
-                        $issue->getValidatorType(),
-                    );
-
-                    $distribution[$filePath] ??= [];
-                    $distribution[$filePath][] = $fileSpecificIssue;
-                }
-            }
-        }
-
-        return $distribution;
     }
 
     public function renderDetailedOutput(OutputInterface $output, array $issues): void
@@ -201,6 +177,17 @@ class HtmlTagValidator extends AbstractValidator implements ValidatorInterface
     public function shouldShowDetailedOutput(): bool
     {
         return true;
+    }
+
+    /**
+     * @return array<string>
+     */
+    protected function extractFilePathsFromIssue(Issue $issue): array
+    {
+        $details = $issue->getDetails();
+        $files = $details['files'] ?? [];
+
+        return array_map(static fn (int|string $key): string => (string) $key, array_keys($files));
     }
 
     protected function resetState(): void

--- a/src/Validator/MismatchValidator.php
+++ b/src/Validator/MismatchValidator.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace MoveElevator\ComposerTranslationValidator\Validator;
 
-use MoveElevator\ComposerTranslationValidator\FileDetector\FileSet;
 use MoveElevator\ComposerTranslationValidator\Parser\{JsonParser, ParserInterface, PhpParser, XliffParser, YamlParser};
 use MoveElevator\ComposerTranslationValidator\Result\Issue;
+use MoveElevator\ComposerTranslationValidator\Validator\Trait\DistributesIssuesForDisplayTrait;
 use Symfony\Component\Console\Helper\{Table, TableStyle};
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -30,6 +30,8 @@ use function in_array;
  */
 class MismatchValidator extends AbstractValidator implements ValidatorInterface
 {
+    use DistributesIssuesForDisplayTrait;
+
     /**
      * @var array<string, array<string, string|null>>
      */
@@ -126,36 +128,6 @@ class MismatchValidator extends AbstractValidator implements ValidatorInterface
         return "- <fg=$color>$level</> {$prefix} the translation key `$key` is $action other translation files (`$otherFilesList`)";
     }
 
-    public function distributeIssuesForDisplay(FileSet $fileSet): array
-    {
-        $distribution = [];
-
-        foreach ($this->issues as $issue) {
-            $details = $issue->getDetails();
-            $files = $details['files'] ?? [];
-
-            foreach ($files as $fileInfo) {
-                $filePath = $fileInfo['file'] ?? '';
-                if (!empty($filePath)) {
-                    $fileSpecificIssue = new Issue(
-                        $filePath,
-                        $details,
-                        $issue->getParser(),
-                        $issue->getValidatorType(),
-                    );
-
-                    if (!isset($distribution[$filePath])) {
-                        $distribution[$filePath] = [];
-                    }
-
-                    $distribution[$filePath][] = $fileSpecificIssue;
-                }
-            }
-        }
-
-        return $distribution;
-    }
-
     public function renderDetailedOutput(OutputInterface $output, array $issues): void
     {
         if (empty($issues)) {
@@ -237,6 +209,22 @@ class MismatchValidator extends AbstractValidator implements ValidatorInterface
     public function shouldShowDetailedOutput(): bool
     {
         return true;
+    }
+
+    protected function extractFilePathsFromIssue(Issue $issue): array
+    {
+        $details = $issue->getDetails();
+        $files = $details['files'] ?? [];
+        $paths = [];
+
+        foreach ($files as $fileInfo) {
+            $filePath = $fileInfo['file'] ?? '';
+            if (!empty($filePath)) {
+                $paths[] = $filePath;
+            }
+        }
+
+        return $paths;
     }
 
     protected function resetState(): void

--- a/src/Validator/PlaceholderConsistencyValidator.php
+++ b/src/Validator/PlaceholderConsistencyValidator.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace MoveElevator\ComposerTranslationValidator\Validator;
 
-use MoveElevator\ComposerTranslationValidator\FileDetector\FileSet;
 use MoveElevator\ComposerTranslationValidator\Parser\{JsonParser, ParserInterface, PhpParser, XliffParser, YamlParser};
 use MoveElevator\ComposerTranslationValidator\Result\Issue;
+use MoveElevator\ComposerTranslationValidator\Validator\Trait\DistributesIssuesForDisplayTrait;
 use Symfony\Component\Console\Helper\{Table, TableStyle};
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -30,6 +30,8 @@ use function in_array;
  */
 class PlaceholderConsistencyValidator extends AbstractValidator implements ValidatorInterface
 {
+    use DistributesIssuesForDisplayTrait;
+
     /** @var array<string, array<string, array{value: string, placeholders: array<string>}>> */
     protected array $keyData = [];
 
@@ -98,32 +100,6 @@ class PlaceholderConsistencyValidator extends AbstractValidator implements Valid
         $inconsistencyText = implode('; ', $inconsistencies);
 
         return "- <fg={$color}>{$level}</> {$prefix}placeholder inconsistency in translation key `{$key}` - {$inconsistencyText}";
-    }
-
-    public function distributeIssuesForDisplay(FileSet $fileSet): array
-    {
-        $distribution = [];
-
-        foreach ($this->issues as $issue) {
-            $details = $issue->getDetails();
-            $files = $details['files'] ?? [];
-
-            foreach ($files as $filePath => $fileInfo) {
-                if (!empty($filePath)) {
-                    $fileSpecificIssue = new Issue(
-                        $filePath,
-                        $details,
-                        $issue->getParser(),
-                        $issue->getValidatorType(),
-                    );
-
-                    $distribution[$filePath] ??= [];
-                    $distribution[$filePath][] = $fileSpecificIssue;
-                }
-            }
-        }
-
-        return $distribution;
     }
 
     public function renderDetailedOutput(OutputInterface $output, array $issues): void
@@ -201,6 +177,17 @@ class PlaceholderConsistencyValidator extends AbstractValidator implements Valid
     public function shouldShowDetailedOutput(): bool
     {
         return true;
+    }
+
+    /**
+     * @return array<string>
+     */
+    protected function extractFilePathsFromIssue(Issue $issue): array
+    {
+        $details = $issue->getDetails();
+        $files = $details['files'] ?? [];
+
+        return array_map(static fn (int|string $key): string => (string) $key, array_keys($files));
     }
 
     protected function resetState(): void

--- a/src/Validator/Trait/DistributesIssuesForDisplayTrait.php
+++ b/src/Validator/Trait/DistributesIssuesForDisplayTrait.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "composer-translation-validator" Composer plugin.
+ *
+ * (c) 2025-2026 Konrad Michalik <km@move-elevator.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace MoveElevator\ComposerTranslationValidator\Validator\Trait;
+
+use MoveElevator\ComposerTranslationValidator\FileDetector\FileSet;
+use MoveElevator\ComposerTranslationValidator\Result\Issue;
+
+/**
+ * DistributesIssuesForDisplayTrait.
+ *
+ * @author Konrad Michalik <km@move-elevator.de>
+ * @license GPL-3.0-or-later
+ */
+trait DistributesIssuesForDisplayTrait
+{
+    /**
+     * @return array<string, array<Issue>>
+     */
+    public function distributeIssuesForDisplay(FileSet $fileSet): array
+    {
+        $distribution = [];
+
+        foreach ($this->issues as $issue) {
+            $filePaths = $this->extractFilePathsFromIssue($issue);
+
+            foreach ($filePaths as $filePath) {
+                if (!empty($filePath)) {
+                    $fileSpecificIssue = new Issue(
+                        $filePath,
+                        $issue->getDetails(),
+                        $issue->getParser(),
+                        $issue->getValidatorType(),
+                    );
+
+                    $distribution[$filePath] ??= [];
+                    $distribution[$filePath][] = $fileSpecificIssue;
+                }
+            }
+        }
+
+        return $distribution;
+    }
+
+    /**
+     * Extract file paths from an issue's details.
+     *
+     * @return array<string>
+     */
+    abstract protected function extractFilePathsFromIssue(Issue $issue): array;
+}

--- a/tests/src/Validator/MismatchValidatorTest.php
+++ b/tests/src/Validator/MismatchValidatorTest.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace MoveElevator\ComposerTranslationValidator\Tests\Validator;
 
+use MoveElevator\ComposerTranslationValidator\FileDetector\FileSet;
 use MoveElevator\ComposerTranslationValidator\Parser\ParserInterface;
+use MoveElevator\ComposerTranslationValidator\Result\Issue;
 use MoveElevator\ComposerTranslationValidator\Validator\MismatchValidator;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -214,7 +216,7 @@ final class MismatchValidatorTest extends TestCase
         $validator = new MismatchValidator($logger);
 
         // Create a mismatch issue
-        $issue = new \MoveElevator\ComposerTranslationValidator\Result\Issue(
+        $issue = new Issue(
             '',
             [
                 'key' => 'test_key',
@@ -228,7 +230,7 @@ final class MismatchValidatorTest extends TestCase
         );
         $validator->addIssue($issue);
 
-        $fileSet = new \MoveElevator\ComposerTranslationValidator\FileDetector\FileSet(
+        $fileSet = new FileSet(
             'TestParser',
             '/test/path',
             'setKey',
@@ -260,7 +262,7 @@ final class MismatchValidatorTest extends TestCase
         $output = new \Symfony\Component\Console\Output\BufferedOutput();
 
         // Create a test issue for detailed output
-        $issue = new \MoveElevator\ComposerTranslationValidator\Result\Issue(
+        $issue = new Issue(
             '',
             [
                 'key' => 'test_key',
@@ -291,7 +293,7 @@ final class MismatchValidatorTest extends TestCase
         $logger = $this->createStub(LoggerInterface::class);
         $validator = new MismatchValidator($logger);
 
-        $issue = new \MoveElevator\ComposerTranslationValidator\Result\Issue(
+        $issue = new Issue(
             'test.xlf',
             [
                 'key' => 'test_key',
@@ -423,5 +425,95 @@ final class MismatchValidatorTest extends TestCase
             $files = $issueArray['issues']['files'];
             $this->assertCount(3, $files);
         }
+    }
+
+    public function testDistributeIssuesForDisplayWithNoIssues(): void
+    {
+        $logger = $this->createStub(LoggerInterface::class);
+        $validator = new MismatchValidator($logger);
+
+        $fileSet = new FileSet('TestParser', '/test/path', 'setKey', ['file1.xlf', 'file2.xlf']);
+        $distribution = $validator->distributeIssuesForDisplay($fileSet);
+
+        $this->assertSame([], $distribution);
+    }
+
+    public function testDistributeIssuesForDisplaySkipsEmptyFilePaths(): void
+    {
+        $logger = $this->createStub(LoggerInterface::class);
+        $validator = new MismatchValidator($logger);
+
+        // Create an issue where one file entry has an empty path
+        $issue = new Issue(
+            '',
+            [
+                'key' => 'test_key',
+                'files' => [
+                    ['file' => '/test/path/file1.xlf', 'value' => 'value1'],
+                    ['file' => '', 'value' => null],
+                ],
+            ],
+            '',
+            'MismatchValidator',
+        );
+        $validator->addIssue($issue);
+
+        $fileSet = new FileSet('TestParser', '/test/path', 'setKey', ['file1.xlf']);
+        $distribution = $validator->distributeIssuesForDisplay($fileSet);
+
+        // Only the non-empty file path should appear in the distribution
+        $this->assertCount(1, $distribution);
+        $this->assertArrayHasKey('/test/path/file1.xlf', $distribution);
+        $this->assertArrayNotHasKey('', $distribution);
+    }
+
+    public function testDistributeIssuesForDisplayDistributesMultipleIssuesAcrossFiles(): void
+    {
+        $logger = $this->createStub(LoggerInterface::class);
+        $validator = new MismatchValidator($logger);
+
+        $issue1 = new Issue(
+            '',
+            [
+                'key' => 'key1',
+                'files' => [
+                    ['file' => '/test/path/en.xlf', 'value' => 'Hello'],
+                    ['file' => '/test/path/de.xlf', 'value' => null],
+                ],
+            ],
+            '',
+            'MismatchValidator',
+        );
+
+        $issue2 = new Issue(
+            '',
+            [
+                'key' => 'key2',
+                'files' => [
+                    ['file' => '/test/path/en.xlf', 'value' => null],
+                    ['file' => '/test/path/de.xlf', 'value' => 'Welt'],
+                ],
+            ],
+            '',
+            'MismatchValidator',
+        );
+
+        $validator->addIssue($issue1);
+        $validator->addIssue($issue2);
+
+        $fileSet = new FileSet('TestParser', '/test/path', 'setKey', ['en.xlf', 'de.xlf']);
+        $distribution = $validator->distributeIssuesForDisplay($fileSet);
+
+        // Both files should have 2 issues each
+        $this->assertCount(2, $distribution);
+        $this->assertCount(2, $distribution['/test/path/en.xlf']);
+        $this->assertCount(2, $distribution['/test/path/de.xlf']);
+
+        // Verify the distributed issues have file-specific paths
+        $enIssue = $distribution['/test/path/en.xlf'][0];
+        $this->assertSame('/test/path/en.xlf', $enIssue->getFile());
+
+        $deIssue = $distribution['/test/path/de.xlf'][0];
+        $this->assertSame('/test/path/de.xlf', $deIssue->getFile());
     }
 }


### PR DESCRIPTION
## Summary

- Extract duplicated `distributeIssuesForDisplay()` logic into a shared trait
- Each validator implements `extractFilePathsFromIssue()` for its specific data format
- Eliminates ~85 lines of duplicated code across three validators

## Changes

- `src/Validator/Trait/DistributesIssuesForDisplayTrait.php` - New trait with unified distribution logic and abstract hook
- `src/Validator/MismatchValidator.php` - Use trait, implement file path extraction for indexed array format
- `src/Validator/PlaceholderConsistencyValidator.php` - Use trait, implement file path extraction for keyed array format
- `src/Validator/HtmlTagValidator.php` - Use trait, implement file path extraction for keyed array format