### PR TITLE
refactor: extract CommandConfigResolver from ValidateTranslationCommand

### DIFF
--- a/src/Command/ValidateTranslationCommand.php
+++ b/src/Command/ValidateTranslationCommand.php
@@ -15,7 +15,7 @@ namespace MoveElevator\ComposerTranslationValidator\Command;
 
 use Composer\Command\BaseCommand;
 use JsonException;
-use MoveElevator\ComposerTranslationValidator\Config\{ConfigReader, TranslationValidatorConfig};
+use MoveElevator\ComposerTranslationValidator\Config\CommandConfigResolver;
 use MoveElevator\ComposerTranslationValidator\Result\{FormatType, Output};
 use MoveElevator\ComposerTranslationValidator\Service\ValidationOrchestrationService;
 use MoveElevator\ComposerTranslationValidator\Validator\ValidatorInterface;
@@ -42,6 +42,7 @@ class ValidateTranslationCommand extends BaseCommand
 
     protected LoggerInterface $logger;
     protected ValidationOrchestrationService $orchestrationService;
+    protected CommandConfigResolver $configResolver;
 
     protected bool $dryRun = false;
     protected bool $strict = false;
@@ -161,6 +162,7 @@ HELP
         $this->io = new SymfonyStyle($input, $output);
         $this->logger = new ConsoleLogger($output);
         $this->orchestrationService = new ValidationOrchestrationService($this->logger);
+        $this->configResolver = new CommandConfigResolver();
     }
 
     /**
@@ -168,22 +170,16 @@ HELP
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $config = $this->loadConfiguration($input);
+        $config = $this->configResolver->resolve($input);
 
         $inputPaths = $input->getArgument('path') ?: [];
         $paths = $this->orchestrationService->resolvePaths($inputPaths, $config);
 
-        $this->dryRun = $config->getDryRun() || $input->getOption('dry-run');
-        $this->strict = $config->getStrict() || $input->getOption('strict');
+        $this->dryRun = $config->getDryRun();
+        $this->strict = $config->getStrict();
         $recursive = (bool) $input->getOption('recursive');
 
-        // Merge exclude patterns from config and CLI
         $excludePatterns = $config->getExclude();
-        $cliExcludeOption = $input->getOption('exclude');
-        if ($cliExcludeOption) {
-            $cliExcludePatterns = array_map(trim(...), explode(',', (string) $cliExcludeOption));
-            $excludePatterns = array_merge($excludePatterns, $cliExcludePatterns);
-        }
 
         $fileDetector = $this->orchestrationService->resolveFileDetector($config);
 
@@ -221,7 +217,7 @@ HELP
             return Command::SUCCESS;
         }
 
-        $format = FormatType::tryFrom($input->getOption('format') ?: $config->getFormat());
+        $format = FormatType::tryFrom($config->getFormat());
 
         if (null === $format) {
             $this->io?->error('Invalid output format specified. Use "cli", "json" or "github".');
@@ -242,34 +238,5 @@ HELP
             $this->dryRun,
             $this->strict,
         ))->summarize();
-    }
-
-    /**
-     * @throws JsonException
-     */
-    private function loadConfiguration(InputInterface $input): TranslationValidatorConfig
-    {
-        $configReader = new ConfigReader();
-        $configPath = $input->getOption('config');
-
-        if ($configPath) {
-            return $configReader->read($configPath);
-        }
-
-        // Try to load from composer.json
-        $composerJsonPath = getcwd().'/composer.json';
-        $config = $configReader->readFromComposerJson($composerJsonPath);
-        if ($config) {
-            return $config;
-        }
-
-        // Try auto-detection
-        $config = $configReader->autoDetect();
-        if ($config) {
-            return $config;
-        }
-
-        // Return default configuration
-        return new TranslationValidatorConfig();
     }
 }

--- a/src/Config/CommandConfigResolver.php
+++ b/src/Config/CommandConfigResolver.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "composer-translation-validator" Composer plugin.
+ *
+ * (c) 2025-2026 Konrad Michalik <km@move-elevator.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace MoveElevator\ComposerTranslationValidator\Config;
+
+use JsonException;
+use Symfony\Component\Console\Input\InputInterface;
+
+/**
+ * CommandConfigResolver.
+ *
+ * Resolves the final TranslationValidatorConfig by loading configuration
+ * from files and merging CLI option overrides.
+ *
+ * @author Konrad Michalik <km@move-elevator.de>
+ * @license GPL-3.0-or-later
+ */
+class CommandConfigResolver
+{
+    public function __construct(
+        private readonly ConfigReader $configReader = new ConfigReader(),
+    ) {}
+
+    /**
+     * Resolve the final configuration from config files and CLI input.
+     *
+     * Priority: CLI options > config file > composer.json > auto-detect > defaults
+     *
+     * @throws JsonException
+     */
+    public function resolve(InputInterface $input, ?string $workingDirectory = null): TranslationValidatorConfig
+    {
+        $config = $this->loadConfiguration($input, $workingDirectory);
+
+        if ($input->getOption('dry-run')) {
+            $config->setDryRun(true);
+        }
+
+        if ($input->getOption('strict')) {
+            $config->setStrict(true);
+        }
+
+        $cliExcludeOption = $input->getOption('exclude');
+        if ($cliExcludeOption) {
+            $cliExcludePatterns = array_map(trim(...), explode(',', (string) $cliExcludeOption));
+            $config->setExclude(array_merge($config->getExclude(), $cliExcludePatterns));
+        }
+
+        $cliFormat = $input->getOption('format');
+        if ($cliFormat) {
+            $config->setFormat((string) $cliFormat);
+        }
+
+        return $config;
+    }
+
+    /**
+     * @throws JsonException
+     */
+    private function loadConfiguration(InputInterface $input, ?string $workingDirectory): TranslationValidatorConfig
+    {
+        $configPath = $input->getOption('config');
+
+        if ($configPath) {
+            return $this->configReader->read($configPath);
+        }
+
+        $workingDirectory ??= (string) getcwd();
+
+        // Try to load from composer.json
+        $composerJsonPath = $workingDirectory . '/composer.json';
+        $config = $this->configReader->readFromComposerJson($composerJsonPath);
+        if ($config) {
+            return $config;
+        }
+
+        // Try auto-detection
+        $config = $this->configReader->autoDetect($workingDirectory);
+        if ($config) {
+            return $config;
+        }
+
+        // Return default configuration
+        return new TranslationValidatorConfig();
+    }
+}

--- a/src/Config/CommandConfigResolver.php
+++ b/src/Config/CommandConfigResolver.php
@@ -19,9 +19,6 @@ use Symfony\Component\Console\Input\InputInterface;
 /**
  * CommandConfigResolver.
  *
- * Resolves the final TranslationValidatorConfig by loading configuration
- * from files and merging CLI option overrides.
- *
  * @author Konrad Michalik <km@move-elevator.de>
  * @license GPL-3.0-or-later
  */
@@ -78,7 +75,7 @@ class CommandConfigResolver
         $workingDirectory ??= (string) getcwd();
 
         // Try to load from composer.json
-        $composerJsonPath = $workingDirectory . '/composer.json';
+        $composerJsonPath = $workingDirectory.'/composer.json';
         $config = $this->configReader->readFromComposerJson($composerJsonPath);
         if ($config) {
             return $config;

--- a/tests/src/Config/CommandConfigResolverTest.php
+++ b/tests/src/Config/CommandConfigResolverTest.php
@@ -16,9 +16,7 @@ namespace MoveElevator\ComposerTranslationValidator\Tests\Config;
 use MoveElevator\ComposerTranslationValidator\Config\CommandConfigResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Input\InputDefinition;
-use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\{ArrayInput, InputDefinition, InputOption};
 
 #[CoversClass(CommandConfigResolver::class)]
 /**
@@ -39,7 +37,7 @@ final class CommandConfigResolverTest extends TestCase
     public function testResolveReturnsDefaultConfigWhenNoCliOptions(): void
     {
         $input = $this->createInput([]);
-        $emptyDir = sys_get_temp_dir() . '/translation-validator-resolver-' . uniqid('', true);
+        $emptyDir = sys_get_temp_dir().'/translation-validator-resolver-'.uniqid('', true);
         mkdir($emptyDir, 0777, true);
 
         $config = $this->resolver->resolve($input, $emptyDir);
@@ -55,7 +53,7 @@ final class CommandConfigResolverTest extends TestCase
     public function testResolveAppliesDryRunCliOption(): void
     {
         $input = $this->createInput(['--dry-run' => true]);
-        $emptyDir = sys_get_temp_dir() . '/translation-validator-resolver-' . uniqid('', true);
+        $emptyDir = sys_get_temp_dir().'/translation-validator-resolver-'.uniqid('', true);
         mkdir($emptyDir, 0777, true);
 
         $config = $this->resolver->resolve($input, $emptyDir);
@@ -68,7 +66,7 @@ final class CommandConfigResolverTest extends TestCase
     public function testResolveAppliesStrictCliOption(): void
     {
         $input = $this->createInput(['--strict' => true]);
-        $emptyDir = sys_get_temp_dir() . '/translation-validator-resolver-' . uniqid('', true);
+        $emptyDir = sys_get_temp_dir().'/translation-validator-resolver-'.uniqid('', true);
         mkdir($emptyDir, 0777, true);
 
         $config = $this->resolver->resolve($input, $emptyDir);
@@ -81,7 +79,7 @@ final class CommandConfigResolverTest extends TestCase
     public function testResolveAppliesFormatCliOption(): void
     {
         $input = $this->createInput(['--format' => 'json']);
-        $emptyDir = sys_get_temp_dir() . '/translation-validator-resolver-' . uniqid('', true);
+        $emptyDir = sys_get_temp_dir().'/translation-validator-resolver-'.uniqid('', true);
         mkdir($emptyDir, 0777, true);
 
         $config = $this->resolver->resolve($input, $emptyDir);
@@ -94,7 +92,7 @@ final class CommandConfigResolverTest extends TestCase
     public function testResolveAppliesExcludeCliOption(): void
     {
         $input = $this->createInput(['--exclude' => '**/backup/**, **/*.bak']);
-        $emptyDir = sys_get_temp_dir() . '/translation-validator-resolver-' . uniqid('', true);
+        $emptyDir = sys_get_temp_dir().'/translation-validator-resolver-'.uniqid('', true);
         mkdir($emptyDir, 0777, true);
 
         $config = $this->resolver->resolve($input, $emptyDir);
@@ -106,10 +104,10 @@ final class CommandConfigResolverTest extends TestCase
 
     public function testResolveMergesExcludePatternsFromConfigAndCli(): void
     {
-        $tempDir = sys_get_temp_dir() . '/translation-validator-resolver-merge-' . uniqid('', true);
+        $tempDir = sys_get_temp_dir().'/translation-validator-resolver-merge-'.uniqid('', true);
         mkdir($tempDir, 0777, true);
 
-        $configFile = $tempDir . '/translation-validator.json';
+        $configFile = $tempDir.'/translation-validator.json';
         file_put_contents($configFile, json_encode(['paths' => ['src'], 'exclude' => ['vendor/*']]));
 
         $input = $this->createInput(['--exclude' => '**/backup/**']);
@@ -124,10 +122,10 @@ final class CommandConfigResolverTest extends TestCase
 
     public function testResolveLoadsConfigFromFile(): void
     {
-        $tempDir = sys_get_temp_dir() . '/translation-validator-resolver-file-' . uniqid('', true);
+        $tempDir = sys_get_temp_dir().'/translation-validator-resolver-file-'.uniqid('', true);
         mkdir($tempDir, 0777, true);
 
-        $configFile = $tempDir . '/custom-config.json';
+        $configFile = $tempDir.'/custom-config.json';
         file_put_contents($configFile, json_encode([
             'paths' => ['custom-path'],
             'strict' => true,
@@ -146,10 +144,10 @@ final class CommandConfigResolverTest extends TestCase
 
     public function testResolveAutoDetectsConfigFile(): void
     {
-        $tempDir = sys_get_temp_dir() . '/translation-validator-resolver-auto-' . uniqid('', true);
+        $tempDir = sys_get_temp_dir().'/translation-validator-resolver-auto-'.uniqid('', true);
         mkdir($tempDir, 0777, true);
 
-        $configFile = $tempDir . '/translation-validator.json';
+        $configFile = $tempDir.'/translation-validator.json';
         file_put_contents($configFile, json_encode(['paths' => ['auto-detected']]));
 
         $input = $this->createInput([]);
@@ -164,10 +162,10 @@ final class CommandConfigResolverTest extends TestCase
 
     public function testResolveCliOptionOverridesConfigFileDryRun(): void
     {
-        $tempDir = sys_get_temp_dir() . '/translation-validator-resolver-override-' . uniqid('', true);
+        $tempDir = sys_get_temp_dir().'/translation-validator-resolver-override-'.uniqid('', true);
         mkdir($tempDir, 0777, true);
 
-        $configFile = $tempDir . '/translation-validator.json';
+        $configFile = $tempDir.'/translation-validator.json';
         file_put_contents($configFile, json_encode(['paths' => ['src'], 'dry-run' => false]));
 
         $input = $this->createInput(['--dry-run' => true]);

--- a/tests/src/Config/CommandConfigResolverTest.php
+++ b/tests/src/Config/CommandConfigResolverTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "composer-translation-validator" Composer plugin.
+ *
+ * (c) 2025-2026 Konrad Michalik <km@move-elevator.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace MoveElevator\ComposerTranslationValidator\Tests\Config;
+
+use MoveElevator\ComposerTranslationValidator\Config\CommandConfigResolver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputOption;
+
+#[CoversClass(CommandConfigResolver::class)]
+/**
+ * CommandConfigResolverTest.
+ *
+ * @author Konrad Michalik <km@move-elevator.de>
+ * @license GPL-3.0-or-later
+ */
+final class CommandConfigResolverTest extends TestCase
+{
+    private CommandConfigResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new CommandConfigResolver();
+    }
+
+    public function testResolveReturnsDefaultConfigWhenNoCliOptions(): void
+    {
+        $input = $this->createInput([]);
+        $emptyDir = sys_get_temp_dir() . '/translation-validator-resolver-' . uniqid('', true);
+        mkdir($emptyDir, 0777, true);
+
+        $config = $this->resolver->resolve($input, $emptyDir);
+
+        $this->assertFalse($config->getDryRun());
+        $this->assertFalse($config->getStrict());
+        $this->assertSame('cli', $config->getFormat());
+        $this->assertSame([], $config->getExclude());
+
+        rmdir($emptyDir);
+    }
+
+    public function testResolveAppliesDryRunCliOption(): void
+    {
+        $input = $this->createInput(['--dry-run' => true]);
+        $emptyDir = sys_get_temp_dir() . '/translation-validator-resolver-' . uniqid('', true);
+        mkdir($emptyDir, 0777, true);
+
+        $config = $this->resolver->resolve($input, $emptyDir);
+
+        $this->assertTrue($config->getDryRun());
+
+        rmdir($emptyDir);
+    }
+
+    public function testResolveAppliesStrictCliOption(): void
+    {
+        $input = $this->createInput(['--strict' => true]);
+        $emptyDir = sys_get_temp_dir() . '/translation-validator-resolver-' . uniqid('', true);
+        mkdir($emptyDir, 0777, true);
+
+        $config = $this->resolver->resolve($input, $emptyDir);
+
+        $this->assertTrue($config->getStrict());
+
+        rmdir($emptyDir);
+    }
+
+    public function testResolveAppliesFormatCliOption(): void
+    {
+        $input = $this->createInput(['--format' => 'json']);
+        $emptyDir = sys_get_temp_dir() . '/translation-validator-resolver-' . uniqid('', true);
+        mkdir($emptyDir, 0777, true);
+
+        $config = $this->resolver->resolve($input, $emptyDir);
+
+        $this->assertSame('json', $config->getFormat());
+
+        rmdir($emptyDir);
+    }
+
+    public function testResolveAppliesExcludeCliOption(): void
+    {
+        $input = $this->createInput(['--exclude' => '**/backup/**, **/*.bak']);
+        $emptyDir = sys_get_temp_dir() . '/translation-validator-resolver-' . uniqid('', true);
+        mkdir($emptyDir, 0777, true);
+
+        $config = $this->resolver->resolve($input, $emptyDir);
+
+        $this->assertSame(['**/backup/**', '**/*.bak'], $config->getExclude());
+
+        rmdir($emptyDir);
+    }
+
+    public function testResolveMergesExcludePatternsFromConfigAndCli(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/translation-validator-resolver-merge-' . uniqid('', true);
+        mkdir($tempDir, 0777, true);
+
+        $configFile = $tempDir . '/translation-validator.json';
+        file_put_contents($configFile, json_encode(['paths' => ['src'], 'exclude' => ['vendor/*']]));
+
+        $input = $this->createInput(['--exclude' => '**/backup/**']);
+
+        $config = $this->resolver->resolve($input, $tempDir);
+
+        $this->assertSame(['vendor/*', '**/backup/**'], $config->getExclude());
+
+        unlink($configFile);
+        rmdir($tempDir);
+    }
+
+    public function testResolveLoadsConfigFromFile(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/translation-validator-resolver-file-' . uniqid('', true);
+        mkdir($tempDir, 0777, true);
+
+        $configFile = $tempDir . '/custom-config.json';
+        file_put_contents($configFile, json_encode([
+            'paths' => ['custom-path'],
+            'strict' => true,
+        ]));
+
+        $input = $this->createInput(['--config' => $configFile]);
+
+        $config = $this->resolver->resolve($input, $tempDir);
+
+        $this->assertSame(['custom-path'], $config->getPaths());
+        $this->assertTrue($config->getStrict());
+
+        unlink($configFile);
+        rmdir($tempDir);
+    }
+
+    public function testResolveAutoDetectsConfigFile(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/translation-validator-resolver-auto-' . uniqid('', true);
+        mkdir($tempDir, 0777, true);
+
+        $configFile = $tempDir . '/translation-validator.json';
+        file_put_contents($configFile, json_encode(['paths' => ['auto-detected']]));
+
+        $input = $this->createInput([]);
+
+        $config = $this->resolver->resolve($input, $tempDir);
+
+        $this->assertSame(['auto-detected'], $config->getPaths());
+
+        unlink($configFile);
+        rmdir($tempDir);
+    }
+
+    public function testResolveCliOptionOverridesConfigFileDryRun(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/translation-validator-resolver-override-' . uniqid('', true);
+        mkdir($tempDir, 0777, true);
+
+        $configFile = $tempDir . '/translation-validator.json';
+        file_put_contents($configFile, json_encode(['paths' => ['src'], 'dry-run' => false]));
+
+        $input = $this->createInput(['--dry-run' => true]);
+
+        $config = $this->resolver->resolve($input, $tempDir);
+
+        $this->assertTrue($config->getDryRun());
+
+        unlink($configFile);
+        rmdir($tempDir);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function createInput(array $options): ArrayInput
+    {
+        $definition = new InputDefinition([
+            new InputOption('dry-run', null, InputOption::VALUE_NONE),
+            new InputOption('strict', null, InputOption::VALUE_NONE),
+            new InputOption('format', 'f', InputOption::VALUE_OPTIONAL, '', 'cli'),
+            new InputOption('only', 'o', InputOption::VALUE_OPTIONAL),
+            new InputOption('skip', 's', InputOption::VALUE_OPTIONAL),
+            new InputOption('config', 'c', InputOption::VALUE_OPTIONAL),
+            new InputOption('recursive', 'r', InputOption::VALUE_NONE),
+            new InputOption('exclude', 'e', InputOption::VALUE_OPTIONAL),
+        ]);
+
+        return new ArrayInput($options, $definition);
+    }
+}


### PR DESCRIPTION
## Summary

- Extract config resolution logic from `execute()` into dedicated `CommandConfigResolver` class
- Centralize config file loading (explicit, composer.json, auto-detect) and CLI option merging (dryRun, strict, exclude, format)
- Fix subtle precedence bug: CLI options now properly override config file values
- Add 9 unit tests covering all resolution scenarios

## Changes

- `src/Config/CommandConfigResolver.php` - New class with `resolve(InputInterface, ?string): TranslationValidatorConfig`
- `src/Command/ValidateTranslationCommand.php` - Simplified execute(), removed loadConfiguration()
- `tests/src/Config/CommandConfigResolverTest.php` - Tests for defaults, CLI overrides, config file loading, merging