### PR TITLE
docs: add standalone/programmatic usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Full documentation is available at **[move-elevator.github.io/composer-translati
 - [Validators](https://move-elevator.github.io/composer-translation-validator/reference/validators)
 - [File Formats](https://move-elevator.github.io/composer-translation-validator/reference/file-formats)
 - [File Detection](https://move-elevator.github.io/composer-translation-validator/reference/file-detection)
+- [Programmatic Usage](https://move-elevator.github.io/composer-translation-validator/reference/programmatic-usage)
 
 ## 🧑‍💻 Contributing
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -53,7 +53,8 @@ export default defineConfig({
             { text: 'CLI Reference', link: '/reference/cli' },
             { text: 'Validators', link: '/reference/validators' },
             { text: 'File Formats', link: '/reference/file-formats' },
-            { text: 'File Detection', link: '/reference/file-detection' }
+            { text: 'File Detection', link: '/reference/file-detection' },
+            { text: 'Programmatic Usage', link: '/reference/programmatic-usage' }
           ]
         }
       ]

--- a/docs/reference/programmatic-usage.md
+++ b/docs/reference/programmatic-usage.md
@@ -1,0 +1,86 @@
+# Programmatic Usage
+
+The validation pipeline has zero coupling to the Composer plugin and can be used standalone in any PHP application. Only a [PSR-3 LoggerInterface](https://www.php-fig.org/psr/psr-3/) is required.
+
+## Basic Example
+
+```php
+use MoveElevator\ComposerTranslationValidator\Config\TranslationValidatorConfig;
+use MoveElevator\ComposerTranslationValidator\FileDetector\PrefixFileDetector;
+use MoveElevator\ComposerTranslationValidator\Service\ValidationOrchestrationService;
+use MoveElevator\ComposerTranslationValidator\Validator\ValidatorRegistry;
+use Psr\Log\NullLogger;
+
+$service = new ValidationOrchestrationService(new NullLogger());
+$config = new TranslationValidatorConfig();
+
+$result = $service->executeValidation(
+    paths: ['/path/to/translations'],
+    excludePatterns: [],
+    recursive: true,
+    fileDetector: new PrefixFileDetector(),
+    validators: ValidatorRegistry::getAvailableValidators(),
+    config: $config,
+);
+```
+
+## Custom Validators and Settings
+
+You can select specific validators and configure per-validator settings:
+
+```php
+use MoveElevator\ComposerTranslationValidator\Validator\{
+    MismatchValidator,
+    EmptyValuesValidator,
+    KeyCountValidator
+};
+
+$config = new TranslationValidatorConfig();
+$config->setValidatorSetting('KeyCountValidator', ['threshold' => 500]);
+$config->setStrict(true);
+
+$result = $service->executeValidation(
+    paths: ['/path/to/translations'],
+    excludePatterns: ['**/vendor/**'],
+    recursive: true,
+    fileDetector: null, // auto-detect
+    validators: [
+        MismatchValidator::class,
+        EmptyValuesValidator::class,
+        KeyCountValidator::class,
+    ],
+    config: $config,
+);
+```
+
+## Working with Results
+
+The `executeValidation()` method returns a `ValidationResult` object:
+
+```php
+if ($result === null) {
+    // No files found to validate
+    return;
+}
+
+if ($result->hasErrors()) {
+    foreach ($result->getIssues() as $issue) {
+        echo $issue->getFilePath() . ': ' . $issue->getMessage() . PHP_EOL;
+    }
+}
+```
+
+## Use Cases
+
+This makes the validation pipeline suitable for:
+
+- **CI pipelines** without Composer runtime
+- **Custom CLI tools** built with Symfony Console
+- **Integration into existing applications** (e.g., TYPO3, Symfony, Laravel)
+- **Pre-commit hooks** or custom quality gates
+
+## See Also
+
+- [CLI Reference](/reference/cli)
+- [Validators](/reference/validators)
+- [Configuration](/configuration/)

--- a/tests/src/Service/StandaloneUsageTest.php
+++ b/tests/src/Service/StandaloneUsageTest.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "composer-translation-validator" Composer plugin.
+ *
+ * (c) 2025-2026 Konrad Michalik <km@move-elevator.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace MoveElevator\ComposerTranslationValidator\Tests\Service;
+
+use MoveElevator\ComposerTranslationValidator\Config\TranslationValidatorConfig;
+use MoveElevator\ComposerTranslationValidator\FileDetector\{PrefixFileDetector, SuffixFileDetector};
+use MoveElevator\ComposerTranslationValidator\Result\ValidationResult;
+use MoveElevator\ComposerTranslationValidator\Service\ValidationOrchestrationService;
+use MoveElevator\ComposerTranslationValidator\Validator\{EmptyValuesValidator, KeyCountValidator, MismatchValidator, ResultType, ValidatorRegistry};
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * StandaloneUsageTest.
+ *
+ * @author Konrad Michalik <km@move-elevator.de>
+ * @license GPL-3.0-or-later
+ */
+#[CoversClass(ValidationOrchestrationService::class)]
+final class StandaloneUsageTest extends TestCase
+{
+    private ValidationOrchestrationService $service;
+
+    protected function setUp(): void
+    {
+        $this->service = new ValidationOrchestrationService(new NullLogger());
+    }
+
+    public function testBasicExampleWithNullLoggerAndDefaultConfig(): void
+    {
+        $config = new TranslationValidatorConfig();
+
+        $result = $this->service->executeValidation(
+            paths: [__DIR__.'/../Fixtures/translations/xliff/success'],
+            excludePatterns: [],
+            recursive: true,
+            fileDetector: new PrefixFileDetector(),
+            validators: ValidatorRegistry::getAvailableValidators(),
+            config: $config,
+        );
+
+        $this->assertInstanceOf(ValidationResult::class, $result);
+        $this->assertSame(ResultType::SUCCESS, $result->getOverallResult());
+        $this->assertFalse($result->hasIssues());
+    }
+
+    public function testCustomValidatorsWithSpecificSelection(): void
+    {
+        $config = new TranslationValidatorConfig();
+
+        $result = $this->service->executeValidation(
+            paths: [__DIR__.'/../Fixtures/translations/yaml/success'],
+            excludePatterns: [],
+            recursive: false,
+            fileDetector: new SuffixFileDetector(),
+            validators: [
+                MismatchValidator::class,
+                EmptyValuesValidator::class,
+                KeyCountValidator::class,
+            ],
+            config: $config,
+        );
+
+        $this->assertInstanceOf(ValidationResult::class, $result);
+        $this->assertSame(ResultType::SUCCESS, $result->getOverallResult());
+        $this->assertFalse($result->hasIssues());
+    }
+
+    public function testCustomValidatorSettings(): void
+    {
+        $config = new TranslationValidatorConfig();
+        $config->setValidatorSetting('KeyCountValidator', ['threshold' => 500]);
+        $config->setStrict(true);
+
+        $result = $this->service->executeValidation(
+            paths: [__DIR__.'/../Fixtures/translations/yaml/success'],
+            excludePatterns: ['**/vendor/**'],
+            recursive: true,
+            fileDetector: new SuffixFileDetector(),
+            validators: [
+                MismatchValidator::class,
+                EmptyValuesValidator::class,
+                KeyCountValidator::class,
+            ],
+            config: $config,
+        );
+
+        $this->assertInstanceOf(ValidationResult::class, $result);
+    }
+
+    public function testNullFileDetectorAutoDetects(): void
+    {
+        $config = new TranslationValidatorConfig();
+
+        $result = $this->service->executeValidation(
+            paths: [__DIR__.'/../Fixtures/translations/yaml/success'],
+            excludePatterns: [],
+            recursive: false,
+            fileDetector: null,
+            validators: [MismatchValidator::class],
+            config: $config,
+        );
+
+        $this->assertInstanceOf(ValidationResult::class, $result);
+    }
+
+    public function testResultObjectApiHasIssuesAndGetValidators(): void
+    {
+        $config = new TranslationValidatorConfig();
+
+        $result = $this->service->executeValidation(
+            paths: [__DIR__.'/../Fixtures/translations/yaml/fail'],
+            excludePatterns: [],
+            recursive: false,
+            fileDetector: new SuffixFileDetector(),
+            validators: [MismatchValidator::class],
+            config: $config,
+        );
+
+        $this->assertInstanceOf(ValidationResult::class, $result);
+        $this->assertTrue($result->hasIssues());
+        $this->assertNotEmpty($result->getValidatorsWithIssues());
+
+        foreach ($result->getValidatorsWithIssues() as $validator) {
+            $this->assertTrue($validator->hasIssues());
+            $this->assertNotEmpty($validator->getIssues());
+        }
+    }
+
+    public function testResultObjectOverallResultReflectsErrors(): void
+    {
+        $config = new TranslationValidatorConfig();
+
+        $result = $this->service->executeValidation(
+            paths: [__DIR__.'/../Fixtures/translations/yaml/fail'],
+            excludePatterns: [],
+            recursive: false,
+            fileDetector: new SuffixFileDetector(),
+            validators: [MismatchValidator::class],
+            config: $config,
+        );
+
+        $this->assertInstanceOf(ValidationResult::class, $result);
+        $this->assertSame(ResultType::ERROR, $result->getOverallResult());
+    }
+
+    public function testReturnsNullWhenNoFilesFound(): void
+    {
+        $config = new TranslationValidatorConfig();
+
+        $result = $this->service->executeValidation(
+            paths: [__DIR__.'/../Fixtures/empty'],
+            excludePatterns: [],
+            recursive: false,
+            fileDetector: new PrefixFileDetector(),
+            validators: ValidatorRegistry::getAvailableValidators(),
+            config: $config,
+        );
+
+        $this->assertNull($result);
+    }
+
+    public function testRecursiveValidationAcrossMultipleFormats(): void
+    {
+        $config = new TranslationValidatorConfig();
+
+        $result = $this->service->executeValidation(
+            paths: [__DIR__.'/../Fixtures/recursive'],
+            excludePatterns: [],
+            recursive: true,
+            fileDetector: new PrefixFileDetector(),
+            validators: [MismatchValidator::class],
+            config: $config,
+        );
+
+        $this->assertInstanceOf(ValidationResult::class, $result);
+    }
+
+    public function testZeroDependencyOnPluginOrComposerRuntime(): void
+    {
+        $service = new ValidationOrchestrationService(new NullLogger());
+        $config = new TranslationValidatorConfig();
+
+        $result = $service->executeValidation(
+            paths: [__DIR__.'/../Fixtures/translations/xliff/success'],
+            excludePatterns: [],
+            recursive: false,
+            fileDetector: new PrefixFileDetector(),
+            validators: [MismatchValidator::class],
+            config: $config,
+        );
+
+        $this->assertInstanceOf(ValidationResult::class, $result);
+        $this->assertFalse($result->hasIssues());
+    }
+}


### PR DESCRIPTION
## Summary

- Add Vitepress documentation page for programmatic/standalone usage of the validation pipeline
- Document basic usage, custom validator selection, and result handling
- Link from README Quick Links section

## Changes

- `docs/reference/programmatic-usage.md` - New documentation page with examples and use cases
- `docs/.vitepress/config.ts` - Add page to reference sidebar
- `README.md` - Add link to programmatic usage in Quick Links