### PR TITLE
Validate target-language in XLF files

### DIFF
--- a/src/Parser/XliffParser.php
+++ b/src/Parser/XliffParser.php
@@ -147,7 +147,8 @@ class XliffParser extends AbstractParser implements ParserInterface
     }
 
     /**
-     * Returns the target language declared in the XLIFF file, or null if not set.
+     * Returns the normalized target language declared in the XLIFF file, or null if not set.
+     * Region suffix is stripped to match getLanguageFromFileName() behavior (e.g. "de-AT" → "de").
      * XLIFF 1.x: target-language attribute on <file>.
      * XLIFF 2.x: trgLang attribute on <xliff>.
      */
@@ -157,7 +158,11 @@ class XliffParser extends AbstractParser implements ParserInterface
             ? (string) ($this->xml['trgLang'] ?? '')
             : (string) ($this->xml->file['target-language'] ?? '');
 
-        return '' !== $lang ? $lang : null;
+        if ('' === $lang) {
+            return null;
+        }
+
+        return strtolower((string) preg_replace('/[-_][^-_]+$/', '', $lang));
     }
 
     private function getSourceLanguage(): string

--- a/src/Parser/XliffParser.php
+++ b/src/Parser/XliffParser.php
@@ -118,6 +118,11 @@ class XliffParser extends AbstractParser implements ParserInterface
         return $this->getLanguageFromFileName() ?? $this->getSourceLanguage();
     }
 
+    public function isVersion2(): bool
+    {
+        return $this->isVersion2;
+    }
+
     /**
      * Extracts the expected locale from the filename, supporting both
      * prefix convention (de.locallang.xlf, TYPO3 style) and

--- a/src/Parser/XliffParser.php
+++ b/src/Parser/XliffParser.php
@@ -16,6 +16,9 @@ namespace MoveElevator\ComposerTranslationValidator\Parser;
 use InvalidArgumentException;
 use SimpleXMLElement;
 
+use function preg_match;
+use function strtolower;
+
 /**
  * XliffParser.
  *
@@ -112,14 +115,48 @@ class XliffParser extends AbstractParser implements ParserInterface
 
     public function getLanguage(): string
     {
-        if (preg_match(
-            '/^([a-z]{2})\./i',
-            $this->getFileName(),
-            $matches,
-        )) {
-            return $matches[1];
+        return $this->getLanguageFromFileName() ?? $this->getSourceLanguage();
+    }
+
+    /**
+     * Extracts the expected locale from the filename, supporting both
+     * prefix convention (de.locallang.xlf, TYPO3 style) and
+     * suffix convention (messages.de.xlf, Symfony/Laravel style).
+     * Returns null if the filename carries no locale.
+     */
+    public function getLanguageFromFileName(): ?string
+    {
+        $fileName = $this->getFileName();
+
+        // Prefix convention: de.locallang.xlf, de_AT.locallang.xlf
+        if (preg_match('/^([a-z]{2}(?:[-_][A-Z]{2})?)\./i', $fileName, $matches)) {
+            return strtolower($matches[1]);
         }
 
+        // Suffix convention: messages.de.xlf, messages.de_AT.xlf
+        if (preg_match('/\.([a-z]{2}(?:[-_][A-Z]{2})?)\.(?:xlf|xliff)$/i', $fileName, $matches)) {
+            return strtolower($matches[1]);
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the target language declared in the XLIFF file, or null if not set.
+     * XLIFF 1.x: target-language attribute on <file>.
+     * XLIFF 2.x: trgLang attribute on <xliff>.
+     */
+    public function getTargetLanguage(): ?string
+    {
+        $lang = $this->isVersion2
+            ? (string) ($this->xml['trgLang'] ?? '')
+            : (string) ($this->xml->file['target-language'] ?? '');
+
+        return '' !== $lang ? $lang : null;
+    }
+
+    private function getSourceLanguage(): string
+    {
         if ($this->isVersion2) {
             return (string) ($this->xml['srcLang'] ?? '');
         }

--- a/src/Parser/XliffParser.php
+++ b/src/Parser/XliffParser.php
@@ -133,13 +133,13 @@ class XliffParser extends AbstractParser implements ParserInterface
     {
         $fileName = $this->getFileName();
 
-        // Prefix convention: de.locallang.xlf, de_AT.locallang.xlf
-        if (preg_match('/^([a-z]{2}(?:[-_][A-Z]{2})?)\./i', $fileName, $matches)) {
+        // Prefix convention: de.locallang.xlf, de_AT.locallang.xlf, de_DE.locallang.xlf
+        if (preg_match('/^([a-z]{2})(?:[-_][A-Z]{2})?\./i', $fileName, $matches)) {
             return strtolower($matches[1]);
         }
 
-        // Suffix convention: messages.de.xlf, messages.de_AT.xlf
-        if (preg_match('/\.([a-z]{2}(?:[-_][A-Z]{2})?)\.(?:xlf|xliff)$/i', $fileName, $matches)) {
+        // Suffix convention: messages.de.xlf, messages.de_AT.xlf, messages.de_DE.xlf
+        if (preg_match('/\.([a-z]{2})(?:[-_][A-Z]{2})?\.(?:xlf|xliff)$/i', $fileName, $matches)) {
             return strtolower($matches[1]);
         }
 

--- a/src/Validator/XliffSchemaValidator.php
+++ b/src/Validator/XliffSchemaValidator.php
@@ -19,7 +19,10 @@ use MoveElevator\ComposerTranslationValidator\Result\Issue;
 use Symfony\Component\Config\Util\XmlUtils;
 use Symfony\Component\Translation\Util\XliffUtils;
 
+use function preg_match;
 use function sprintf;
+use function strtolower;
+use function version_compare;
 
 /**
  * XliffSchemaValidator.
@@ -31,40 +34,79 @@ class XliffSchemaValidator extends AbstractValidator implements ValidatorInterfa
 {
     public function processFile(ParserInterface $file): array
     {
+        /*
+         * With XmlUtils::loadFile() we always get a strange symfony error related to global composer autoloading issue.
+         *      Call to undefined method Symfony\Component\Filesystem\Filesystem::readFile()
+         */
+        if (!file_exists($file->getFilePath())) {
+            $this->logger?->error('File does not exist: '.$file->getFileName());
+
+            return [];
+        }
+
+        $fileContent = file_get_contents($file->getFilePath());
+        if (false === $fileContent) {
+            $this->logger?->error('Failed to read file: '.$file->getFileName());
+
+            return [];
+        }
+
         try {
-            /*
-             * With XmlUtils::loadFile() we always get a strange symfony error related to global composer autoloading issue.
-             *      Call to undefined method Symfony\Component\Filesystem\Filesystem::readFile()
-             */
-            if (!file_exists($file->getFilePath())) {
-                $this->logger?->error('File does not exist: '.$file->getFileName());
-
-                return [];
-            }
-
-            $fileContent = file_get_contents($file->getFilePath());
-            if (false === $fileContent) {
-                $this->logger?->error('Failed to read file: '.$file->getFileName());
-
-                return [];
-            }
             $dom = XmlUtils::parse($fileContent);
-            $errors = XliffUtils::validateSchema($dom);
+        } catch (Exception $e) {
+            $this->logger?->error('Failed to validate XML schema: '.$e->getMessage());
+
+            return [];
+        }
+
+        // Schema validation — may throw for unsupported XLIFF versions (e.g. 2.x)
+        $errors = [];
+        try {
+            $errors = array_values(XliffUtils::validateSchema($dom));
         } catch (Exception $e) {
             if (str_contains($e->getMessage(), 'No support implemented for loading XLIFF version')) {
                 $this->logger?->notice(sprintf('Skipping %s: %s', $this->getShortName(), $e->getMessage()));
             } else {
                 $this->logger?->error('Failed to validate XML schema: '.$e->getMessage());
             }
-
-            return [];
         }
 
-        if (!empty($errors)) {
-            return $errors;
+        // Additional check: if filename starts with language code, verify it matches target-language in file header
+        $fileName = $file->getFileName();
+        if (preg_match('/^([a-z]{2})\./i', $fileName, $matches)) {
+            $expectedLanguage = strtolower($matches[1]);
+
+            $xliffRoot = $dom->documentElement;
+            $version = $xliffRoot?->getAttribute('version') ?? '';
+            $isVersion2 = version_compare($version, '2.0', '>=');
+
+            if ($isVersion2) {
+                $targetLang = $xliffRoot?->getAttribute('trgLang') ?? '';
+            } else {
+                $targetLang = $dom->documentElement?->firstElementChild?->getAttribute('target-language') ?? '';
+            }
+
+            if ('' === $targetLang) {
+                $errors[] = [
+                    'message' => sprintf(
+                        'Missing "target-language" attribute on <file> node; expected "%s" based on filename',
+                        $expectedLanguage,
+                    ),
+                    'level' => 'ERROR',
+                ];
+            } elseif (strtolower($targetLang) !== $expectedLanguage) {
+                $errors[] = [
+                    'message' => sprintf(
+                        '"target-language" attribute "%s" does not match filename language "%s"',
+                        $targetLang,
+                        $expectedLanguage,
+                    ),
+                    'level' => 'ERROR',
+                ];
+            }
         }
 
-        return [];
+        return $errors;
     }
 
     public function formatIssueMessage(Issue $issue, string $prefix = ''): string

--- a/src/Validator/XliffSchemaValidator.php
+++ b/src/Validator/XliffSchemaValidator.php
@@ -19,10 +19,8 @@ use MoveElevator\ComposerTranslationValidator\Result\Issue;
 use Symfony\Component\Config\Util\XmlUtils;
 use Symfony\Component\Translation\Util\XliffUtils;
 
-use function preg_match;
 use function sprintf;
 use function strtolower;
-use function version_compare;
 
 /**
  * XliffSchemaValidator.
@@ -62,7 +60,7 @@ class XliffSchemaValidator extends AbstractValidator implements ValidatorInterfa
         // Schema validation — may throw for unsupported XLIFF versions (e.g. 2.x)
         $errors = [];
         try {
-            $errors = array_values(XliffUtils::validateSchema($dom));
+            $errors = XliffUtils::validateSchema($dom);
         } catch (Exception $e) {
             if (str_contains($e->getMessage(), 'No support implemented for loading XLIFF version')) {
                 $this->logger?->notice(sprintf('Skipping %s: %s', $this->getShortName(), $e->getMessage()));
@@ -71,22 +69,16 @@ class XliffSchemaValidator extends AbstractValidator implements ValidatorInterfa
             }
         }
 
-        // Additional check: if filename starts with language code, verify it matches target-language in file header
-        $fileName = $file->getFileName();
-        if (preg_match('/^([a-z]{2})\./i', $fileName, $matches)) {
-            $expectedLanguage = strtolower($matches[1]);
+        // Additional check: if filename encodes a locale, verify it matches target-language in the file header
+        if (!$file instanceof XliffParser) {
+            return $errors;
+        }
 
-            $xliffRoot = $dom->documentElement;
-            $version = $xliffRoot?->getAttribute('version') ?? '';
-            $isVersion2 = version_compare($version, '2.0', '>=');
+        $expectedLanguage = $file->getLanguageFromFileName();
+        if (null !== $expectedLanguage) {
+            $targetLang = $file->getTargetLanguage();
 
-            if ($isVersion2) {
-                $targetLang = $xliffRoot?->getAttribute('trgLang') ?? '';
-            } else {
-                $targetLang = $dom->documentElement?->firstElementChild?->getAttribute('target-language') ?? '';
-            }
-
-            if ('' === $targetLang) {
+            if (null === $targetLang) {
                 $errors[] = [
                     'message' => sprintf(
                         'Missing "target-language" attribute on <file> node; expected "%s" based on filename',

--- a/src/Validator/XliffSchemaValidator.php
+++ b/src/Validator/XliffSchemaValidator.php
@@ -54,7 +54,7 @@ class XliffSchemaValidator extends AbstractValidator implements ValidatorInterfa
         try {
             $dom = XmlUtils::parse($fileContent);
         } catch (Exception $e) {
-            $this->logger?->error('Failed to validate XML schema: '.$e->getMessage());
+            $this->logger?->error('Failed to parse XML: '.$e->getMessage());
 
             return [];
         }

--- a/src/Validator/XliffSchemaValidator.php
+++ b/src/Validator/XliffSchemaValidator.php
@@ -77,11 +77,16 @@ class XliffSchemaValidator extends AbstractValidator implements ValidatorInterfa
         $expectedLanguage = $file->getLanguageFromFileName();
         if (null !== $expectedLanguage) {
             $targetLang = $file->getTargetLanguage();
+            $isVersion2 = $file->isVersion2();
+            $attribute = $isVersion2 ? 'trgLang' : 'target-language';
+            $element = $isVersion2 ? '<xliff>' : '<file>';
 
             if (null === $targetLang) {
                 $errors[] = [
                     'message' => sprintf(
-                        'Missing "target-language" attribute on <file> node; expected "%s" based on filename',
+                        'Missing "%s" attribute on %s node; expected "%s" based on filename',
+                        $attribute,
+                        $element,
                         $expectedLanguage,
                     ),
                     'level' => 'ERROR',
@@ -89,7 +94,8 @@ class XliffSchemaValidator extends AbstractValidator implements ValidatorInterfa
             } elseif (strtolower($targetLang) !== $expectedLanguage) {
                 $errors[] = [
                     'message' => sprintf(
-                        '"target-language" attribute "%s" does not match filename language "%s"',
+                        '"%s" attribute "%s" does not match filename language "%s"',
+                        $attribute,
                         $targetLang,
                         $expectedLanguage,
                     ),

--- a/tests/src/Parser/XliffParserTest.php
+++ b/tests/src/Parser/XliffParserTest.php
@@ -423,6 +423,24 @@ EOT;
         $this->assertSame('de', $parser->getLanguageFromFileName());
     }
 
+    public function testGetLanguageFromFileNamePrefixConventionWithRegion(): void
+    {
+        $file = $this->tempDir.'/de_DE.locallang.xlf';
+        file_put_contents($file, $this->prefixedXliffContent);
+
+        $parser = new XliffParser($file);
+        $this->assertSame('de', $parser->getLanguageFromFileName());
+    }
+
+    public function testGetLanguageFromFileNameSuffixConventionWithRegion(): void
+    {
+        $file = $this->tempDir.'/messages.de_DE.xlf';
+        file_put_contents($file, $this->targetLanguageXliffContent);
+
+        $parser = new XliffParser($file);
+        $this->assertSame('de', $parser->getLanguageFromFileName());
+    }
+
     public function testGetLanguageFromFileNameReturnsNullForSourceFile(): void
     {
         $parser = new XliffParser($this->validXliffFile); // messages.xlf — no locale

--- a/tests/src/Parser/XliffParserTest.php
+++ b/tests/src/Parser/XliffParserTest.php
@@ -411,6 +411,54 @@ EOT;
         $this->assertSame('en', $parser->getLanguage());
     }
 
+    public function testGetLanguageFromFileNamePrefixConvention(): void
+    {
+        $parser = new XliffParser($this->prefixedXliffFile); // de.messages.xlf
+        $this->assertSame('de', $parser->getLanguageFromFileName());
+    }
+
+    public function testGetLanguageFromFileNameSuffixConvention(): void
+    {
+        $parser = new XliffParser($this->targetLanguageXliffFile); // messages.de.xlf
+        $this->assertSame('de', $parser->getLanguageFromFileName());
+    }
+
+    public function testGetLanguageFromFileNameReturnsNullForSourceFile(): void
+    {
+        $parser = new XliffParser($this->validXliffFile); // messages.xlf — no locale
+        $this->assertNull($parser->getLanguageFromFileName());
+    }
+
+    public function testGetLanguageFromFileNameReturnsNullForXliff2SourceFile(): void
+    {
+        $parser = new XliffParser($this->xliff2File); // messages_v2.xlf — no locale
+        $this->assertNull($parser->getLanguageFromFileName());
+    }
+
+    public function testGetTargetLanguageReturnsValueWhenSet(): void
+    {
+        $parser = new XliffParser($this->targetLanguageXliffFile); // target-language="de"
+        $this->assertSame('de', $parser->getTargetLanguage());
+    }
+
+    public function testGetTargetLanguageReturnsNullWhenNotSet(): void
+    {
+        $parser = new XliffParser($this->validXliffFile); // no target-language attribute
+        $this->assertNull($parser->getTargetLanguage());
+    }
+
+    public function testGetTargetLanguageXliff2ReturnsValueWhenSet(): void
+    {
+        $parser = new XliffParser($this->xliff2TargetFile); // trgLang="de"
+        $this->assertSame('de', $parser->getTargetLanguage());
+    }
+
+    public function testGetTargetLanguageXliff2ReturnsNullWhenNotSet(): void
+    {
+        $parser = new XliffParser($this->xliff2File); // no trgLang
+        $this->assertNull($parser->getTargetLanguage());
+    }
+
     public function testGetContentByKeyFallsBackToSourceWhenTargetIsEmptyXliff2(): void
     {
         $fallbackFile = $this->tempDir.'/v2_fallback.xlf';

--- a/tests/src/Parser/XliffParserTest.php
+++ b/tests/src/Parser/XliffParserTest.php
@@ -477,6 +477,48 @@ EOT;
         $this->assertNull($parser->getTargetLanguage());
     }
 
+    public function testGetTargetLanguageStripsRegionSuffixWithHyphen(): void
+    {
+        $file = $this->tempDir.'/region_hyphen.xlf';
+        file_put_contents($file, <<<'EOT'
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="de-AT" datatype="plaintext" original="region_hyphen.xlf">
+    <body><trans-unit id="k"><source>x</source></trans-unit></body>
+  </file>
+</xliff>
+EOT);
+        $this->assertSame('de', (new XliffParser($file))->getTargetLanguage());
+    }
+
+    public function testGetTargetLanguageStripsRegionSuffixWithUnderscore(): void
+    {
+        $file = $this->tempDir.'/region_underscore.xlf';
+        file_put_contents($file, <<<'EOT'
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="de_AT" datatype="plaintext" original="region_underscore.xlf">
+    <body><trans-unit id="k"><source>x</source></trans-unit></body>
+  </file>
+</xliff>
+EOT);
+        $this->assertSame('de', (new XliffParser($file))->getTargetLanguage());
+    }
+
+    public function testGetTargetLanguageXliff2StripsRegionSuffix(): void
+    {
+        $file = $this->tempDir.'/region_v2.xlf';
+        file_put_contents($file, <<<'EOT'
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="de-AT">
+  <file id="messages">
+    <unit id="k"><segment><source>x</source></segment></unit>
+  </file>
+</xliff>
+EOT);
+        $this->assertSame('de', (new XliffParser($file))->getTargetLanguage());
+    }
+
     public function testGetContentByKeyFallsBackToSourceWhenTargetIsEmptyXliff2(): void
     {
         $fallbackFile = $this->tempDir.'/v2_fallback.xlf';

--- a/tests/src/Validator/XliffSchemaValidatorTest.php
+++ b/tests/src/Validator/XliffSchemaValidatorTest.php
@@ -238,4 +238,137 @@ XML;
         $expected = '- <fg=red>Error</> Schema validation error';
         $this->assertSame($expected, $result);
     }
+
+    public function testProcessFileWithMissingTargetLanguage(): void
+    {
+        $xliff = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" original="messages" datatype="plaintext">
+        <body>
+            <trans-unit id="test">
+                <source>Hello</source>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>
+XML;
+
+        $tempFile = tempnam(sys_get_temp_dir(), 'xliff_test_');
+        file_put_contents($tempFile, $xliff);
+
+        $parser = $this->createStub(XliffParser::class);
+        $parser->method('getFilePath')->willReturn($tempFile);
+        $parser->method('getFileName')->willReturn('de.locallang.xlf');
+
+        $result = $this->validator->processFile($parser);
+
+        unlink($tempFile);
+
+        $targetLangErrors = array_filter(
+            $result,
+            static fn ($e) => isset($e['message']) && str_contains($e['message'], 'target-language'),
+        );
+        $this->assertCount(1, $targetLangErrors);
+        $error = array_values($targetLangErrors)[0];
+        $this->assertStringContainsString('Missing "target-language"', $error['message']);
+        $this->assertStringContainsString('"de"', $error['message']);
+    }
+
+    public function testProcessFileWithMismatchedTargetLanguage(): void
+    {
+        $xliff = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" target-language="fr" original="messages" datatype="plaintext">
+        <body>
+            <trans-unit id="test">
+                <source>Hello</source>
+                <target>Hallo</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>
+XML;
+
+        $tempFile = tempnam(sys_get_temp_dir(), 'xliff_test_');
+        file_put_contents($tempFile, $xliff);
+
+        $parser = $this->createStub(XliffParser::class);
+        $parser->method('getFilePath')->willReturn($tempFile);
+        $parser->method('getFileName')->willReturn('de.locallang.xlf');
+
+        $result = $this->validator->processFile($parser);
+
+        unlink($tempFile);
+
+        $this->assertCount(1, $result);
+        $this->assertStringContainsString('"fr"', $result[0]['message']);
+        $this->assertStringContainsString('"de"', $result[0]['message']);
+    }
+
+    public function testProcessFileWithoutLanguagePrefixSkipsTargetLanguageCheck(): void
+    {
+        $xliff = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" original="messages" datatype="plaintext">
+        <body>
+            <trans-unit id="test">
+                <source>Hello</source>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>
+XML;
+
+        $tempFile = tempnam(sys_get_temp_dir(), 'xliff_test_');
+        file_put_contents($tempFile, $xliff);
+
+        $parser = $this->createStub(XliffParser::class);
+        $parser->method('getFilePath')->willReturn($tempFile);
+        $parser->method('getFileName')->willReturn('locallang.xlf');
+
+        $result = $this->validator->processFile($parser);
+
+        unlink($tempFile);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testProcessFileXliff2WithMissingTrgLang(): void
+    {
+        $xliff = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en">
+    <file id="messages">
+        <unit id="test">
+            <segment>
+                <source>Hello</source>
+            </segment>
+        </unit>
+    </file>
+</xliff>
+XML;
+
+        $tempFile = tempnam(sys_get_temp_dir(), 'xliff_test_');
+        file_put_contents($tempFile, $xliff);
+
+        $parser = $this->createStub(XliffParser::class);
+        $parser->method('getFilePath')->willReturn($tempFile);
+        $parser->method('getFileName')->willReturn('de.locallang.xlf');
+
+        $result = $this->validator->processFile($parser);
+
+        unlink($tempFile);
+
+        $hasTargetLangError = false;
+        foreach ($result as $error) {
+            if (isset($error['message']) && str_contains($error['message'], 'target-language')) {
+                $hasTargetLangError = true;
+                break;
+            }
+        }
+        $this->assertTrue($hasTargetLangError, 'Expected a target-language error for XLIFF 2.x without trgLang');
+    }
 }

--- a/tests/src/Validator/XliffSchemaValidatorTest.php
+++ b/tests/src/Validator/XliffSchemaValidatorTest.php
@@ -273,6 +273,34 @@ XML;
         $this->assertStringContainsString('"de"', $error['message']);
     }
 
+    public function testProcessFileWithRegionInFilenameAndAttributeIsNotAFalsePositive(): void
+    {
+        $xliff = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" target-language="de-AT" original="messages" datatype="plaintext">
+        <body>
+            <trans-unit id="test">
+                <source>Hello</source>
+                <target>Hallo</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>
+XML;
+
+        $tempDir = sys_get_temp_dir();
+        $tempFile = $tempDir.'/de_AT.locallang.xlf';
+        file_put_contents($tempFile, $xliff);
+
+        $parser = new XliffParser($tempFile);
+        $result = $this->validator->processFile($parser);
+
+        unlink($tempFile);
+
+        $this->assertSame([], $result);
+    }
+
     public function testProcessFileWithMismatchedTargetLanguage(): void
     {
         $xliff = <<<'XML'

--- a/tests/src/Validator/XliffSchemaValidatorTest.php
+++ b/tests/src/Validator/XliffSchemaValidatorTest.php
@@ -356,12 +356,12 @@ XML;
 
         $hasTargetLangError = false;
         foreach ($result as $error) {
-            if (isset($error['message']) && str_contains($error['message'], 'target-language')) {
+            if (isset($error['message']) && str_contains($error['message'], 'trgLang')) {
                 $hasTargetLangError = true;
                 break;
             }
         }
-        $this->assertTrue($hasTargetLangError, 'Expected a target-language error for XLIFF 2.x without trgLang');
+        $this->assertTrue($hasTargetLangError, 'Expected a trgLang error for XLIFF 2.x without trgLang');
     }
 
     public function testProcessFileXliff2WithMismatchedTrgLang(): void
@@ -391,7 +391,7 @@ XML;
 
         $mismatchErrors = array_filter(
             $result,
-            static fn ($e) => isset($e['message']) && str_contains($e['message'], 'target-language'),
+            static fn ($e) => isset($e['message']) && str_contains($e['message'], 'trgLang'),
         );
         $this->assertCount(1, $mismatchErrors);
         $error = array_values($mismatchErrors)[0];

--- a/tests/src/Validator/XliffSchemaValidatorTest.php
+++ b/tests/src/Validator/XliffSchemaValidatorTest.php
@@ -111,7 +111,7 @@ XML;
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects($this->once())
             ->method('error')
-            ->with($this->stringContains('Failed to validate XML schema:'));
+            ->with($this->stringContains('Failed to parse XML:'));
 
         $validator = new XliffSchemaValidator($logger);
         $result = $validator->processFile($parser);

--- a/tests/src/Validator/XliffSchemaValidatorTest.php
+++ b/tests/src/Validator/XliffSchemaValidatorTest.php
@@ -254,13 +254,11 @@ XML;
 </xliff>
 XML;
 
-        $tempFile = tempnam(sys_get_temp_dir(), 'xliff_test_');
+        $tempDir = sys_get_temp_dir();
+        $tempFile = $tempDir.'/de.locallang.xlf';
         file_put_contents($tempFile, $xliff);
 
-        $parser = $this->createStub(XliffParser::class);
-        $parser->method('getFilePath')->willReturn($tempFile);
-        $parser->method('getFileName')->willReturn('de.locallang.xlf');
-
+        $parser = new XliffParser($tempFile);
         $result = $this->validator->processFile($parser);
 
         unlink($tempFile);
@@ -291,13 +289,11 @@ XML;
 </xliff>
 XML;
 
-        $tempFile = tempnam(sys_get_temp_dir(), 'xliff_test_');
+        $tempDir = sys_get_temp_dir();
+        $tempFile = $tempDir.'/de.locallang.xlf';
         file_put_contents($tempFile, $xliff);
 
-        $parser = $this->createStub(XliffParser::class);
-        $parser->method('getFilePath')->willReturn($tempFile);
-        $parser->method('getFileName')->willReturn('de.locallang.xlf');
-
+        $parser = new XliffParser($tempFile);
         $result = $this->validator->processFile($parser);
 
         unlink($tempFile);
@@ -322,13 +318,11 @@ XML;
 </xliff>
 XML;
 
-        $tempFile = tempnam(sys_get_temp_dir(), 'xliff_test_');
+        $tempDir = sys_get_temp_dir();
+        $tempFile = $tempDir.'/locallang.xlf';
         file_put_contents($tempFile, $xliff);
 
-        $parser = $this->createStub(XliffParser::class);
-        $parser->method('getFilePath')->willReturn($tempFile);
-        $parser->method('getFileName')->willReturn('locallang.xlf');
-
+        $parser = new XliffParser($tempFile);
         $result = $this->validator->processFile($parser);
 
         unlink($tempFile);
@@ -351,13 +345,11 @@ XML;
 </xliff>
 XML;
 
-        $tempFile = tempnam(sys_get_temp_dir(), 'xliff_test_');
+        $tempDir = sys_get_temp_dir();
+        $tempFile = $tempDir.'/de.locallang.xlf';
         file_put_contents($tempFile, $xliff);
 
-        $parser = $this->createStub(XliffParser::class);
-        $parser->method('getFilePath')->willReturn($tempFile);
-        $parser->method('getFileName')->willReturn('de.locallang.xlf');
-
+        $parser = new XliffParser($tempFile);
         $result = $this->validator->processFile($parser);
 
         unlink($tempFile);
@@ -370,5 +362,40 @@ XML;
             }
         }
         $this->assertTrue($hasTargetLangError, 'Expected a target-language error for XLIFF 2.x without trgLang');
+    }
+
+    public function testProcessFileXliff2WithMismatchedTrgLang(): void
+    {
+        $xliff = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">
+    <file id="messages">
+        <unit id="test">
+            <segment>
+                <source>Hello</source>
+                <target>Bonjour</target>
+            </segment>
+        </unit>
+    </file>
+</xliff>
+XML;
+
+        $tempDir = sys_get_temp_dir();
+        $tempFile = $tempDir.'/de.locallang.xlf';
+        file_put_contents($tempFile, $xliff);
+
+        $parser = new XliffParser($tempFile);
+        $result = $this->validator->processFile($parser);
+
+        unlink($tempFile);
+
+        $mismatchErrors = array_filter(
+            $result,
+            static fn ($e) => isset($e['message']) && str_contains($e['message'], 'target-language'),
+        );
+        $this->assertCount(1, $mismatchErrors);
+        $error = array_values($mismatchErrors)[0];
+        $this->assertStringContainsString('"fr"', $error['message']);
+        $this->assertStringContainsString('"de"', $error['message']);
     }
 }


### PR DESCRIPTION
This PR adds an additional check to the `XliffSchemaValidator`. Translated language files should have a `target-language` attribute that matches it's filename. Otherwise an error should be thrown.

Attention: AI generated code.

resolves #118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Filename-encoded locales are validated against XLIFF target-language declarations.

* **Improvements**
  * Improved handling and logging for unreadable/invalid XML while preserving validation results.
  * Parser detects XLIFF version, extracts target language, supports filename prefix/suffix and region variants (case-insensitive compare).

* **Tests**
  * Added tests for filename locale extraction and target-language checks across XLIFF 1.x and 2.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->