### PR TITLE
fix: treat HTML void elements as self-closing in HtmlTagValidator

### DIFF
--- a/src/Validator/HtmlTagValidator.php
+++ b/src/Validator/HtmlTagValidator.php
@@ -32,6 +32,17 @@ class HtmlTagValidator extends AbstractValidator implements ValidatorInterface
 {
     use DistributesIssuesForDisplayTrait;
 
+    /**
+     * HTML5 void elements — they never have a closing tag, regardless of an
+     * explicit trailing slash (`<br>` and `<br/>` are equivalent).
+     *
+     * @var string[]
+     */
+    private const VOID_ELEMENTS = [
+        'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input',
+        'link', 'meta', 'param', 'source', 'track', 'wbr',
+    ];
+
     /** @var array<string, array<string, array{value: string, html_structure: array<string, mixed>}>> */
     protected array $keyData = [];
 
@@ -228,8 +239,8 @@ class HtmlTagValidator extends AbstractValidator implements ValidatorInterface
                     }
                 } else {
                     // Opening tag or self-closing
-                    if (str_ends_with($attributes, '/')) {
-                        // Self-closing tag
+                    if (str_ends_with($attributes, '/') || in_array($tagName, self::VOID_ELEMENTS, true)) {
+                        // Self-closing or HTML void element — never pushed onto the stack
                         $structure['self_closing_tags'][] = $tagName;
                         $attributes = rtrim($attributes, ' /');
                     } else {

--- a/tests/src/Validator/HtmlTagValidatorTest.php
+++ b/tests/src/Validator/HtmlTagValidatorTest.php
@@ -93,6 +93,35 @@ final class HtmlTagValidatorTest extends TestCase
         $this->assertContains('Unmatched closing tag: </span>', $structure['structure_errors']);
     }
 
+    public function testVoidElementsAreNotReportedAsUnclosed(): void
+    {
+        $validator = new HtmlTagValidator();
+        $reflection = new ReflectionClass($validator);
+        $method = $reflection->getMethod('analyzeHtmlStructure');
+
+        // Non-self-closing void element (HTML5 syntax, e.g. from CDATA)
+        $structure = $method->invoke($validator, 'Test<br>Test');
+        $this->assertEmpty($structure['structure_errors']);
+        $this->assertContains('br', $structure['tags']);
+
+        // <br>, <br/> and <br /> must be treated equivalently (no errors)
+        foreach (['Line<br>here', 'Line<br/>here', 'Line<br />here'] as $value) {
+            $structure = $method->invoke($validator, $value);
+            $this->assertEmpty($structure['structure_errors'], "Unexpected error for: {$value}");
+            $this->assertContains('br', $structure['tags']);
+        }
+
+        // Void element with attributes
+        $structure = $method->invoke($validator, 'Image <img src="x.png"> done');
+        $this->assertEmpty($structure['structure_errors']);
+        $this->assertContains('img', $structure['tags']);
+        $this->assertSame('x.png', $structure['attributes']['img']['src'] ?? null);
+
+        // Regression guard: real non-void tags must still be flagged
+        $structure = $method->invoke($validator, 'Unclosed <div>content');
+        $this->assertContains('Unclosed tag: <div>', $structure['structure_errors']);
+    }
+
     public function testPostProcessWithConsistentHtml(): void
     {
         $parser1 = $this->createStub(ParserInterface::class);


### PR DESCRIPTION
## Summary

- Fix false-positive `Unclosed tag` warnings in `HtmlTagValidator` for HTML5 void elements such as `<br>`, `<img>`, `<hr>` (closes #132)
- Void elements without a trailing slash were pushed onto the tag stack and reported as unclosed; the validator effectively assumed XHTML syntax (`<br/>`)
- `<br>`, `<br/>` and `<br />` are now treated equivalently; void elements are still tracked in `tags` so genuine cross-file inconsistencies remain detected

## Changes

- `src/Validator/HtmlTagValidator.php` - Add HTML5 `VOID_ELEMENTS` list; treat void elements as self-closing in `analyzeHtmlStructure()` (not pushed onto the tag stack)
- `tests/src/Validator/HtmlTagValidatorTest.php` - Add `testVoidElementsAreNotReportedAsUnclosed` covering `<br>`/`<br/>`/`<br />` equivalence, void elements with attributes, and an unclosed-`<div>` regression guard