### PR TITLE
feat: warn on region mismatch between filename locale and target-language

### DIFF
--- a/docs/reference/validators.md
+++ b/docs/reference/validators.md
@@ -697,6 +697,14 @@ composer -d tests validate-translations Fixtures/examples/xliff-schema --only "M
 
 </details>
 
+### Target Language Consistency
+
+When the filename encodes a locale (e.g. `de_DE.locallang.xlf` or `messages.de_DE.xlf`), the declared `target-language` (XLIFF 1.x) or `trgLang` (XLIFF 2.x) is checked against it:
+
+- **Base language mismatch** (e.g. filename `de` vs. `target-language="fr"`) → **ERROR**
+- **Region mismatch** (e.g. filename `de_DE` vs. `target-language="de-AT"`) → **WARNING**
+- A missing region on either side is not reported (e.g. filename `de_DE` with `target-language="de"` is fine).
+
 ::: danger
 Malformed XLIFF files can crash translation tools or cause parsing errors in your application.
 :::

--- a/src/Enum/LocaleMatch.php
+++ b/src/Enum/LocaleMatch.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "composer-translation-validator" Composer plugin.
+ *
+ * (c) 2025-2026 Konrad Michalik <km@move-elevator.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace MoveElevator\ComposerTranslationValidator\Enum;
+
+/**
+ * LocaleMatch.
+ *
+ * @author Konrad Michalik <km@move-elevator.de>
+ * @license GPL-3.0-or-later
+ */
+enum LocaleMatch
+{
+    case Identical;
+    case RegionMismatch;
+    case BaseMismatch;
+}

--- a/src/Parser/XliffParser.php
+++ b/src/Parser/XliffParser.php
@@ -14,10 +14,10 @@ declare(strict_types=1);
 namespace MoveElevator\ComposerTranslationValidator\Parser;
 
 use InvalidArgumentException;
+use MoveElevator\ComposerTranslationValidator\Utility\LocaleUtility;
 use SimpleXMLElement;
 
 use function preg_match;
-use function strtolower;
 
 /**
  * XliffParser.
@@ -124,45 +124,63 @@ class XliffParser extends AbstractParser implements ParserInterface
     }
 
     /**
-     * Extracts the expected locale from the filename, supporting both
-     * prefix convention (de.locallang.xlf, TYPO3 style) and
-     * suffix convention (messages.de.xlf, Symfony/Laravel style).
-     * Returns null if the filename carries no locale.
+     * Returns the base language extracted from the filename, or null if none.
+     * Region is stripped (e.g. "de_DE.locallang.xlf" → "de").
      */
     public function getLanguageFromFileName(): ?string
+    {
+        $locale = $this->getLocaleFromFileName();
+
+        return null === $locale ? null : LocaleUtility::parse($locale)['base'];
+    }
+
+    /**
+     * Extracts the full locale from the filename, preserving the region, supporting both
+     * prefix convention (de.locallang.xlf, TYPO3 style) and
+     * suffix convention (messages.de.xlf, Symfony/Laravel style).
+     * Returns null if the filename carries no locale (e.g. "de_DE" or "de").
+     */
+    public function getLocaleFromFileName(): ?string
     {
         $fileName = $this->getFileName();
 
         // Prefix convention: de.locallang.xlf, de_AT.locallang.xlf, de_DE.locallang.xlf
-        if (preg_match('/^([a-z]{2})(?:[-_][A-Z]{2})?\./i', $fileName, $matches)) {
-            return strtolower($matches[1]);
+        if (preg_match('/^([a-z]{2}(?:[-_][a-z]{2})?)\./i', $fileName, $matches)) {
+            return $matches[1];
         }
 
         // Suffix convention: messages.de.xlf, messages.de_AT.xlf, messages.de_DE.xlf
-        if (preg_match('/\.([a-z]{2})(?:[-_][A-Z]{2})?\.(?:xlf|xliff)$/i', $fileName, $matches)) {
-            return strtolower($matches[1]);
+        if (preg_match('/\.([a-z]{2}(?:[-_][a-z]{2})?)\.(?:xlf|xliff)$/i', $fileName, $matches)) {
+            return $matches[1];
         }
 
         return null;
     }
 
     /**
-     * Returns the normalized target language declared in the XLIFF file, or null if not set.
-     * Region suffix is stripped to match getLanguageFromFileName() behavior (e.g. "de-AT" → "de").
+     * Returns the base target language declared in the XLIFF file, or null if not set.
+     * Region is stripped (e.g. "de-AT" → "de").
+     */
+    public function getTargetLanguage(): ?string
+    {
+        $locale = $this->getTargetLocale();
+
+        return null === $locale ? null : LocaleUtility::parse($locale)['base'];
+    }
+
+    /**
+     * Returns the full target locale declared in the XLIFF file, preserving the region,
+     * or null if not set.
      * XLIFF 1.x: target-language attribute on <file>.
      * XLIFF 2.x: trgLang attribute on <xliff>.
      */
-    public function getTargetLanguage(): ?string
+    public function getTargetLocale(): ?string
     {
         $lang = $this->isVersion2
             ? (string) ($this->xml['trgLang'] ?? '')
             : (string) ($this->xml->file['target-language'] ?? '');
 
-        if ('' === $lang) {
-            return null;
-        }
-
-        return strtolower((string) preg_replace('/[-_][^-_]+$/', '', $lang));
+        return '' === $lang ? null : $lang;
     }
 
     private function getSourceLanguage(): string

--- a/src/Parser/XliffParser.php
+++ b/src/Parser/XliffParser.php
@@ -41,9 +41,11 @@ class XliffParser extends AbstractParser implements ParserInterface
         parent::__construct($filePath);
 
         $xmlContent = file_get_contents($filePath);
+        // @codeCoverageIgnoreStart
         if (false === $xmlContent) {
             throw new InvalidArgumentException("Failed to read file: {$filePath}");
         }
+        // @codeCoverageIgnoreEnd
 
         libxml_use_internal_errors(true);
         $this->xml = simplexml_load_string($xmlContent);
@@ -144,13 +146,13 @@ class XliffParser extends AbstractParser implements ParserInterface
     {
         $fileName = $this->getFileName();
 
-        // Prefix convention: de.locallang.xlf, de_AT.locallang.xlf, de_DE.locallang.xlf
-        if (preg_match('/^([a-z]{2}(?:[-_][a-z]{2})?)\./i', $fileName, $matches)) {
+        // Prefix convention: de.locallang.xlf, de_AT.locallang.xlf, es_419.locallang.xlf
+        if (preg_match('/^([a-z]{2}(?:[-_](?:[a-z]{2}|[0-9]{3}))?)\./i', $fileName, $matches)) {
             return $matches[1];
         }
 
-        // Suffix convention: messages.de.xlf, messages.de_AT.xlf, messages.de_DE.xlf
-        if (preg_match('/\.([a-z]{2}(?:[-_][a-z]{2})?)\.(?:xlf|xliff)$/i', $fileName, $matches)) {
+        // Suffix convention: messages.de.xlf, messages.de_AT.xlf, messages.es_419.xlf
+        if (preg_match('/\.([a-z]{2}(?:[-_](?:[a-z]{2}|[0-9]{3}))?)\.(?:xlf|xliff)$/i', $fileName, $matches)) {
             return $matches[1];
         }
 

--- a/src/Utility/LocaleUtility.php
+++ b/src/Utility/LocaleUtility.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "composer-translation-validator" Composer plugin.
+ *
+ * (c) 2025-2026 Konrad Michalik <km@move-elevator.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace MoveElevator\ComposerTranslationValidator\Utility;
+
+use MoveElevator\ComposerTranslationValidator\Enum\LocaleMatch;
+
+use function strtolower;
+use function strtoupper;
+
+/**
+ * LocaleUtility.
+ *
+ * @author Konrad Michalik <km@move-elevator.de>
+ * @license GPL-3.0-or-later
+ */
+class LocaleUtility
+{
+    /**
+     * Splits a locale into its base language (lowercase) and region (uppercase, or null).
+     *
+     * @return array{base: string, region: ?string}
+     */
+    public static function parse(string $locale): array
+    {
+        $parts = preg_split('/[-_]/', $locale, 2);
+        $base = strtolower((string) ($parts[0] ?? ''));
+        $region = isset($parts[1]) && '' !== $parts[1]
+            ? strtoupper($parts[1])
+            : null;
+
+        return ['base' => $base, 'region' => $region];
+    }
+
+    /**
+     * Compares two locales. A missing region on either side is not treated as a
+     * mismatch — only two present-but-differing regions count as RegionMismatch.
+     */
+    public static function compare(string $a, string $b): LocaleMatch
+    {
+        $localeA = self::parse($a);
+        $localeB = self::parse($b);
+
+        if ($localeA['base'] !== $localeB['base']) {
+            return LocaleMatch::BaseMismatch;
+        }
+
+        if (null !== $localeA['region']
+            && null !== $localeB['region']
+            && $localeA['region'] !== $localeB['region']
+        ) {
+            return LocaleMatch::RegionMismatch;
+        }
+
+        return LocaleMatch::Identical;
+    }
+}

--- a/src/Validator/XliffSchemaValidator.php
+++ b/src/Validator/XliffSchemaValidator.php
@@ -14,13 +14,14 @@ declare(strict_types=1);
 namespace MoveElevator\ComposerTranslationValidator\Validator;
 
 use Exception;
+use MoveElevator\ComposerTranslationValidator\Enum\LocaleMatch;
 use MoveElevator\ComposerTranslationValidator\Parser\{ParserInterface, XliffParser};
 use MoveElevator\ComposerTranslationValidator\Result\Issue;
+use MoveElevator\ComposerTranslationValidator\Utility\LocaleUtility;
 use Symfony\Component\Config\Util\XmlUtils;
 use Symfony\Component\Translation\Util\XliffUtils;
 
 use function sprintf;
-use function strtolower;
 
 /**
  * XliffSchemaValidator.
@@ -74,33 +75,47 @@ class XliffSchemaValidator extends AbstractValidator implements ValidatorInterfa
             return $errors;
         }
 
-        $expectedLanguage = $file->getLanguageFromFileName();
-        if (null !== $expectedLanguage) {
-            $targetLang = $file->getTargetLanguage();
+        $expectedLocale = $file->getLocaleFromFileName();
+        if (null !== $expectedLocale) {
+            $targetLocale = $file->getTargetLocale();
             $isVersion2 = $file->isVersion2();
             $attribute = $isVersion2 ? 'trgLang' : 'target-language';
             $element = $isVersion2 ? '<xliff>' : '<file>';
 
-            if (null === $targetLang) {
+            if (null === $targetLocale) {
                 $errors[] = [
                     'message' => sprintf(
                         'Missing "%s" attribute on %s node; expected "%s" based on filename',
                         $attribute,
                         $element,
-                        $expectedLanguage,
+                        $expectedLocale,
                     ),
                     'level' => 'ERROR',
                 ];
-            } elseif (strtolower($targetLang) !== $expectedLanguage) {
-                $errors[] = [
-                    'message' => sprintf(
-                        '"%s" attribute "%s" does not match filename language "%s"',
-                        $attribute,
-                        $targetLang,
-                        $expectedLanguage,
-                    ),
-                    'level' => 'ERROR',
-                ];
+            } else {
+                $match = LocaleUtility::compare($targetLocale, $expectedLocale);
+
+                if (LocaleMatch::BaseMismatch === $match) {
+                    $errors[] = [
+                        'message' => sprintf(
+                            '"%s" attribute "%s" does not match filename language "%s"',
+                            $attribute,
+                            $targetLocale,
+                            $expectedLocale,
+                        ),
+                        'level' => 'ERROR',
+                    ];
+                } elseif (LocaleMatch::RegionMismatch === $match) {
+                    $errors[] = [
+                        'message' => sprintf(
+                            '"%s" attribute "%s" has a different region than filename locale "%s"',
+                            $attribute,
+                            $targetLocale,
+                            $expectedLocale,
+                        ),
+                        'level' => 'WARNING',
+                    ];
+                }
             }
         }
 

--- a/tests/src/Parser/XliffParserTest.php
+++ b/tests/src/Parser/XliffParserTest.php
@@ -519,6 +519,68 @@ EOT);
         $this->assertSame('de', (new XliffParser($file))->getTargetLanguage());
     }
 
+    public function testGetLocaleFromFileNamePreservesRegionPrefix(): void
+    {
+        $file = $this->tempDir.'/de_DE.locallang.xlf';
+        file_put_contents($file, $this->prefixedXliffContent);
+
+        $this->assertSame('de_DE', (new XliffParser($file))->getLocaleFromFileName());
+    }
+
+    public function testGetLocaleFromFileNamePreservesRegionSuffix(): void
+    {
+        $file = $this->tempDir.'/messages.de_DE.xlf';
+        file_put_contents($file, $this->targetLanguageXliffContent);
+
+        $this->assertSame('de_DE', (new XliffParser($file))->getLocaleFromFileName());
+    }
+
+    public function testGetLocaleFromFileNameReturnsBaseWhenNoRegion(): void
+    {
+        $parser = new XliffParser($this->prefixedXliffFile); // de.messages.xlf
+        $this->assertSame('de', $parser->getLocaleFromFileName());
+    }
+
+    public function testGetLocaleFromFileNameReturnsNullForSourceFile(): void
+    {
+        $parser = new XliffParser($this->validXliffFile); // messages.xlf — no locale
+        $this->assertNull($parser->getLocaleFromFileName());
+    }
+
+    public function testGetTargetLocalePreservesRegion(): void
+    {
+        $file = $this->tempDir.'/region_full.xlf';
+        file_put_contents($file, <<<'EOT'
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="de-AT" datatype="plaintext" original="region_full.xlf">
+    <body><trans-unit id="k"><source>x</source></trans-unit></body>
+  </file>
+</xliff>
+EOT);
+        $this->assertSame('de-AT', (new XliffParser($file))->getTargetLocale());
+    }
+
+    public function testGetTargetLocaleXliff2PreservesRegion(): void
+    {
+        $file = $this->tempDir.'/region_full_v2.xlf';
+        file_put_contents($file, <<<'EOT'
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="de-AT">
+  <file id="messages">
+    <unit id="k"><segment><source>x</source></segment></unit>
+  </file>
+</xliff>
+EOT);
+        $this->assertSame('de-AT', (new XliffParser($file))->getTargetLocale());
+    }
+
+    public function testGetTargetLocaleReturnsNullWhenNotSet(): void
+    {
+        $parser = new XliffParser($this->validXliffFile); // no target-language attribute
+        $this->assertNull($parser->getTargetLocale());
+    }
+
     public function testGetContentByKeyFallsBackToSourceWhenTargetIsEmptyXliff2(): void
     {
         $fallbackFile = $this->tempDir.'/v2_fallback.xlf';

--- a/tests/src/Parser/XliffParserTest.php
+++ b/tests/src/Parser/XliffParserTest.php
@@ -541,6 +541,14 @@ EOT);
         $this->assertSame('de', $parser->getLocaleFromFileName());
     }
 
+    public function testGetLocaleFromFileNamePreservesNonAlphaSubtag(): void
+    {
+        $file = $this->tempDir.'/messages.es_419.xlf';
+        file_put_contents($file, $this->targetLanguageXliffContent);
+
+        $this->assertSame('es_419', (new XliffParser($file))->getLocaleFromFileName());
+    }
+
     public function testGetLocaleFromFileNameReturnsNullForSourceFile(): void
     {
         $parser = new XliffParser($this->validXliffFile); // messages.xlf — no locale

--- a/tests/src/Utility/LocaleUtilityTest.php
+++ b/tests/src/Utility/LocaleUtilityTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "composer-translation-validator" Composer plugin.
+ *
+ * (c) 2025-2026 Konrad Michalik <km@move-elevator.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace MoveElevator\ComposerTranslationValidator\Tests\Utility;
+
+use MoveElevator\ComposerTranslationValidator\Enum\LocaleMatch;
+use MoveElevator\ComposerTranslationValidator\Utility\LocaleUtility;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * LocaleUtilityTest.
+ *
+ * @author Konrad Michalik <km@move-elevator.de>
+ * @license GPL-3.0-or-later
+ */
+final class LocaleUtilityTest extends TestCase
+{
+    /**
+     * @param array{base: string, region: ?string} $expected
+     */
+    #[DataProvider('parseProvider')]
+    public function testParse(string $locale, array $expected): void
+    {
+        self::assertSame($expected, LocaleUtility::parse($locale));
+    }
+
+    /**
+     * @return iterable<string, array{string, array{base: string, region: ?string}}>
+     */
+    public static function parseProvider(): iterable
+    {
+        yield 'base only' => ['de', ['base' => 'de', 'region' => null]];
+        yield 'hyphen region' => ['de-AT', ['base' => 'de', 'region' => 'AT']];
+        yield 'underscore region' => ['de_DE', ['base' => 'de', 'region' => 'DE']];
+        yield 'lowercase region' => ['de-at', ['base' => 'de', 'region' => 'AT']];
+        yield 'mixed case base' => ['DE_de', ['base' => 'de', 'region' => 'DE']];
+        yield 'empty' => ['', ['base' => '', 'region' => null]];
+    }
+
+    #[DataProvider('compareProvider')]
+    public function testCompare(string $a, string $b, LocaleMatch $expected): void
+    {
+        self::assertSame($expected, LocaleUtility::compare($a, $b));
+    }
+
+    /**
+     * @return iterable<string, array{string, string, LocaleMatch}>
+     */
+    public static function compareProvider(): iterable
+    {
+        yield 'identical base' => ['de', 'de', LocaleMatch::Identical];
+        yield 'identical full locale' => ['de-AT', 'de_AT', LocaleMatch::Identical];
+        yield 'identical case-insensitive' => ['DE-at', 'de_AT', LocaleMatch::Identical];
+        yield 'region mismatch' => ['de-AT', 'de_DE', LocaleMatch::RegionMismatch];
+        yield 'base mismatch' => ['de', 'fr', LocaleMatch::BaseMismatch];
+        yield 'base mismatch with regions' => ['de-AT', 'fr-FR', LocaleMatch::BaseMismatch];
+        yield 'missing region one side is not a mismatch' => ['de', 'de-AT', LocaleMatch::Identical];
+        yield 'missing region other side is not a mismatch' => ['de-AT', 'de', LocaleMatch::Identical];
+    }
+}

--- a/tests/src/Validator/XliffSchemaValidatorTest.php
+++ b/tests/src/Validator/XliffSchemaValidatorTest.php
@@ -301,6 +301,97 @@ XML;
         $this->assertSame([], $result);
     }
 
+    public function testProcessFileWithRegionMismatchEmitsWarning(): void
+    {
+        $xliff = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" target-language="de-AT" original="messages" datatype="plaintext">
+        <body>
+            <trans-unit id="test">
+                <source>Hello</source>
+                <target>Hallo</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>
+XML;
+
+        $tempDir = sys_get_temp_dir();
+        $tempFile = $tempDir.'/de_DE.locallang.xlf';
+        file_put_contents($tempFile, $xliff);
+
+        $parser = new XliffParser($tempFile);
+        $result = $this->validator->processFile($parser);
+
+        unlink($tempFile);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('WARNING', $result[0]['level']);
+        $this->assertStringContainsString('different region', $result[0]['message']);
+        $this->assertStringContainsString('de-AT', $result[0]['message']);
+        $this->assertStringContainsString('de_DE', $result[0]['message']);
+    }
+
+    public function testProcessFileWithRegionMismatchSuffixConventionEmitsWarning(): void
+    {
+        $xliff = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" target-language="de-AT" original="messages" datatype="plaintext">
+        <body>
+            <trans-unit id="test">
+                <source>Hello</source>
+                <target>Hallo</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>
+XML;
+
+        $tempDir = sys_get_temp_dir();
+        $tempFile = $tempDir.'/messages.de_DE.xlf';
+        file_put_contents($tempFile, $xliff);
+
+        $parser = new XliffParser($tempFile);
+        $result = $this->validator->processFile($parser);
+
+        unlink($tempFile);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('WARNING', $result[0]['level']);
+    }
+
+    public function testProcessFileXliff2WithRegionMismatchEmitsWarning(): void
+    {
+        $xliff = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="de-AT">
+    <file id="messages">
+        <unit id="test">
+            <segment>
+                <source>Hello</source>
+                <target>Hallo</target>
+            </segment>
+        </unit>
+    </file>
+</xliff>
+XML;
+
+        $tempDir = sys_get_temp_dir();
+        $tempFile = $tempDir.'/de_DE.locallang.xlf';
+        file_put_contents($tempFile, $xliff);
+
+        $parser = new XliffParser($tempFile);
+        $result = $this->validator->processFile($parser);
+
+        unlink($tempFile);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('WARNING', $result[0]['level']);
+        $this->assertStringContainsString('trgLang', $result[0]['message']);
+    }
+
     public function testProcessFileWithMismatchedTargetLanguage(): void
     {
         $xliff = <<<'XML'

--- a/tests/src/Validator/XliffSchemaValidatorTest.php
+++ b/tests/src/Validator/XliffSchemaValidatorTest.php
@@ -317,14 +317,17 @@ XML;
 </xliff>
 XML;
 
-        $tempDir = sys_get_temp_dir();
+        $tempDir = sys_get_temp_dir().'/xliff_schema_'.uniqid('', true);
+        mkdir($tempDir);
         $tempFile = $tempDir.'/de_DE.locallang.xlf';
         file_put_contents($tempFile, $xliff);
 
-        $parser = new XliffParser($tempFile);
-        $result = $this->validator->processFile($parser);
-
-        unlink($tempFile);
+        try {
+            $result = $this->validator->processFile(new XliffParser($tempFile));
+        } finally {
+            unlink($tempFile);
+            rmdir($tempDir);
+        }
 
         $this->assertCount(1, $result);
         $this->assertSame('WARNING', $result[0]['level']);
@@ -349,14 +352,17 @@ XML;
 </xliff>
 XML;
 
-        $tempDir = sys_get_temp_dir();
+        $tempDir = sys_get_temp_dir().'/xliff_schema_'.uniqid('', true);
+        mkdir($tempDir);
         $tempFile = $tempDir.'/messages.de_DE.xlf';
         file_put_contents($tempFile, $xliff);
 
-        $parser = new XliffParser($tempFile);
-        $result = $this->validator->processFile($parser);
-
-        unlink($tempFile);
+        try {
+            $result = $this->validator->processFile(new XliffParser($tempFile));
+        } finally {
+            unlink($tempFile);
+            rmdir($tempDir);
+        }
 
         $this->assertCount(1, $result);
         $this->assertSame('WARNING', $result[0]['level']);
@@ -378,14 +384,17 @@ XML;
 </xliff>
 XML;
 
-        $tempDir = sys_get_temp_dir();
+        $tempDir = sys_get_temp_dir().'/xliff_schema_'.uniqid('', true);
+        mkdir($tempDir);
         $tempFile = $tempDir.'/de_DE.locallang.xlf';
         file_put_contents($tempFile, $xliff);
 
-        $parser = new XliffParser($tempFile);
-        $result = $this->validator->processFile($parser);
-
-        unlink($tempFile);
+        try {
+            $result = $this->validator->processFile(new XliffParser($tempFile));
+        } finally {
+            unlink($tempFile);
+            rmdir($tempDir);
+        }
 
         $this->assertCount(1, $result);
         $this->assertSame('WARNING', $result[0]['level']);


### PR DESCRIPTION
## Summary

Follow-up to #119. The XLIFF target-language check previously normalized both the filename locale and the `target-language`/`trgLang` attribute to the base language before comparing, silently accepting region-level inconsistencies (e.g. `de_DE.locallang.xlf` declaring `target-language="de-AT"`).

- Keep base-language mismatches as `ERROR` (unchanged behavior).
- Emit a `WARNING` when the base language matches but the regions differ.
- Lift locale parsing/comparison into a reusable `LocaleUtility` so other validators can reuse it (suggested by @maikschneider in #119).
- A missing region on either side is not reported (e.g. filename `de_DE` with `target-language="de"` stays fine).

Out of scope: BCP 47 conformance of the region itself (e.g. whether `de-XX` is a real region).

Closes #122

## Changes

- `src/Enum/LocaleMatch.php` - New enum: `Identical` / `RegionMismatch` / `BaseMismatch`
- `src/Utility/LocaleUtility.php` - New `parse()` (base + region) and `compare()` helpers, accepting both `-` and `_` separators, case-insensitive
- `src/Parser/XliffParser.php` - New `getLocaleFromFileName()` / `getTargetLocale()` preserving the region; existing base-only methods now delegate to `LocaleUtility::parse`, so `getLanguage()` is unchanged
- `src/Validator/XliffSchemaValidator.php` - Three-way comparison via `LocaleUtility::compare` (ERROR / WARNING / no issue)
- `docs/reference/validators.md` - Document the target-language consistency check
- `tests/src/Utility/LocaleUtilityTest.php`, `tests/src/Parser/XliffParserTest.php`, `tests/src/Validator/XliffSchemaValidatorTest.php` - Coverage for parsing, region preservation, and the new WARNING across XLIFF 1.x/2.x and prefix/suffix conventions

## Test plan

- [x] `composer test` - full suite green (818 tests)
- [x] `composer sca` - PHPStan, no errors
- [x] `composer lint` - code style clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added locale comparison support with clear handling for exact matches, region-only mismatches, and base-language mismatches.
* **Bug Fixes**
  * Improved language checks so filename and XLIFF target locale comparisons now respect regional variants and produce warnings only when appropriate.
* **Documentation**
  * Added guidance on target-language consistency checks, including expected error and warning behavior.
* **Tests**
  * Expanded coverage for locale parsing, locale comparison, and region-mismatch validation across XLIFF formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->