### PR TITLE
docs: correct CLI validator-selection usage and complete reference

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -8,6 +8,8 @@ The `validate-translations` command is the main interface for the Composer Trans
 composer validate-translations [<path>...] [options]
 ```
 
+The command is also available under the alias `vt`.
+
 ## Arguments
 
 | Argument | Description |
@@ -19,8 +21,8 @@ composer validate-translations [<path>...] [options]
 | Option | Shortcut | Description |
 |--------|----------|-------------|
 | `--format` | `-f` | Sets the output format: `cli`, `json`, or `github` |
-| `--skip` | `-s` | Skips specific validators (can be used multiple times) |
-| `--only` | `-o` | Runs only the specified validators (can be used multiple times) |
+| `--skip` | `-s` | Skips specific validators (FQCN, comma-separated) |
+| `--only` | `-o` | Runs only the specified validators (FQCN, comma-separated) |
 | `--recursive` | `-r` | Search for translation files recursively in subdirectories |
 | `--exclude` | `-e` | Exclude files matching glob patterns, comma-separated |
 | `--verbose` | `-v` | Shows additional output for detailed information |
@@ -98,10 +100,11 @@ composer validate-translations ./translations \
 
 ### Multiple Validators
 
+Pass several validators as a single comma-separated value:
+
 ```bash
 composer validate-translations ./translations \
-  --only "MoveElevator\\ComposerTranslationValidator\\Validator\\MismatchValidator" \
-  --only "MoveElevator\\ComposerTranslationValidator\\Validator\\DuplicateKeysValidator"
+  --only "MoveElevator\\ComposerTranslationValidator\\Validator\\MismatchValidator,MoveElevator\\ComposerTranslationValidator\\Validator\\DuplicateKeysValidator"
 ```
 
 ### Using a Configuration File

--- a/docs/reference/validators.md
+++ b/docs/reference/validators.md
@@ -722,10 +722,11 @@ composer validate-translations ./translations \
 
 ### Run Multiple Validators
 
+Pass several validators as a single comma-separated value:
+
 ```bash
 composer validate-translations ./translations \
-  --only "MoveElevator\\ComposerTranslationValidator\\Validator\\MismatchValidator" \
-  --only "MoveElevator\\ComposerTranslationValidator\\Validator\\DuplicateKeysValidator"
+  --only "MoveElevator\\ComposerTranslationValidator\\Validator\\MismatchValidator,MoveElevator\\ComposerTranslationValidator\\Validator\\DuplicateKeysValidator"
 ```
 
 ### Skip Validators
@@ -739,7 +740,5 @@ composer validate-translations ./translations \
 
 ```bash
 composer validate-translations ./translations \
-  --only "MoveElevator\\ComposerTranslationValidator\\Validator\\MismatchValidator" \
-  --only "MoveElevator\\ComposerTranslationValidator\\Validator\\DuplicateKeysValidator" \
-  --only "MoveElevator\\ComposerTranslationValidator\\Validator\\XliffSchemaValidator"
+  --only "MoveElevator\\ComposerTranslationValidator\\Validator\\MismatchValidator,MoveElevator\\ComposerTranslationValidator\\Validator\\DuplicateKeysValidator,MoveElevator\\ComposerTranslationValidator\\Validator\\XliffSchemaValidator"
 ```

--- a/src/Command/ValidateTranslationCommand.php
+++ b/src/Command/ValidateTranslationCommand.php
@@ -133,6 +133,8 @@ using multiple validators to ensure consistency, correctness and schema complian
   • <info>EncodingValidator</info>        - Validates file encoding and character issues
   • <info>HtmlTagValidator</info>         - Validates HTML tag consistency across translations
   • <info>KeyNamingConventionValidator</info> - Validates translation key naming conventions
+  • <info>KeyCountValidator</info>        - Warns when a file exceeds the key count threshold
+  • <info>KeyDepthValidator</info>        - Warns when keys exceed the nesting depth threshold
   • <info>PlaceholderConsistencyValidator</info> - Validates placeholder consistency across files
   • <info>XliffSchemaValidator</info>     - Validates XLIFF schema compliance
 


### PR DESCRIPTION
## Summary

- Fix incorrect `--only`/`--skip` documentation: these are single comma-separated options (`VALUE_OPTIONAL`, split on `,`), not repeatable flags — repeated flags would only keep the last value
- Document the `vt` command alias, which was undocumented
- Complete the in-command `--help` validator list (added `KeyCountValidator` and `KeyDepthValidator`, previously only 9 of 11 were listed)

## Changes

- `docs/reference/cli.md` - Correct `--only`/`--skip` description and "Multiple Validators" example to comma-separated; document `vt` alias
- `docs/reference/validators.md` - Correct "Run Multiple Validators" and "Focus on Critical Issues Only" examples to comma-separated
- `src/Command/ValidateTranslationCommand.php` - List all 11 validators in the command help text