### PR TITLE
fix: parse PHP translation files via AST instead of executing them

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
 		"ext-simplexml": "*",
 		"composer-plugin-api": "^1.0 || ^2.0",
 		"justinrainbow/json-schema": "^5.3 || ^6.4",
+		"nikic/php-parser": "^5.0",
 		"psr/log": "^1.0 || ^2.0 || ^3.0",
 		"symfony/config": "^6.0 || ^7.0 || ^8.0",
 		"symfony/console": "^6.0 || ^7.0 || ^8.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b72dd8ab852c54f894044f9081ac8731",
+    "content-hash": "e90e462f4ee4fec7672626304dbc0ab4",
     "packages": [
         {
             "name": "justinrainbow/json-schema",
@@ -153,6 +153,63 @@
                 "source": "https://github.com/marc-mabe/php-enum/tree/v4.7.2"
             },
             "time": "2025-09-14T11:18:39+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
+            },
+            "time": "2026-07-04T14:30:18+00:00"
         },
         {
             "name": "psr/container",
@@ -3192,64 +3249,6 @@
                 }
             ],
             "time": "2025-08-01T08:46:24+00:00"
-        },
-        {
-            "name": "nikic/php-parser",
-            "version": "v5.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
-                "shasum": ""
-            },
-            "require": {
-                "ext-ctype": "*",
-                "ext-json": "*",
-                "ext-tokenizer": "*",
-                "php": ">=7.4"
-            },
-            "require-dev": {
-                "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^9.0"
-            },
-            "bin": [
-                "bin/php-parse"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PhpParser\\": "lib/PhpParser"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Nikita Popov"
-                }
-            ],
-            "description": "A PHP parser written in PHP",
-            "keywords": [
-                "parser",
-                "php"
-            ],
-            "support": {
-                "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
-            },
-            "time": "2025-12-06T11:56:16+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -7005,5 +7004,5 @@
         "composer-plugin-api": "^1.0 || ^2.0"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -155,6 +155,63 @@
             "time": "2025-09-14T11:18:39+00:00"
         },
         {
+            "name": "nikic/php-parser",
+            "version": "v5.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
+            },
+            "time": "2026-07-04T14:30:18+00:00"
+        },
+        {
             "name": "psr/container",
             "version": "2.0.2",
             "source": {
@@ -3192,63 +3249,6 @@
                 }
             ],
             "time": "2025-08-01T08:46:24+00:00"
-        },
-        {
-            "name": "nikic/php-parser",
-            "version": "v5.8.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
-                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "ext-tokenizer": "*",
-                "php": ">=7.4"
-            },
-            "require-dev": {
-                "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^9.0"
-            },
-            "bin": [
-                "bin/php-parse"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PhpParser\\": "lib/PhpParser"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Nikita Popov"
-                }
-            ],
-            "description": "A PHP parser written in PHP",
-            "keywords": [
-                "parser",
-                "php"
-            ],
-            "support": {
-                "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
-            },
-            "time": "2026-07-04T14:30:18+00:00"
         },
         {
             "name": "phar-io/manifest",

--- a/src/Parser/PhpParser.php
+++ b/src/Parser/PhpParser.php
@@ -13,14 +13,21 @@ declare(strict_types=1);
 
 namespace MoveElevator\ComposerTranslationValidator\Parser;
 
+use PhpParser\Node\Expr\{Array_, ConstFetch, UnaryMinus};
+use PhpParser\Node\Scalar\{Float_, Int_, String_};
+use PhpParser\Node\Stmt\Return_;
+use PhpParser\{Node, NodeFinder, ParserFactory};
 use RuntimeException;
 use Throwable;
 
 use function array_key_exists;
 use function dirname;
 use function is_array;
+use function is_float;
+use function is_int;
 use function is_string;
 use function sprintf;
+use function strtolower;
 
 /**
  * PhpParser.
@@ -30,7 +37,7 @@ use function sprintf;
  */
 class PhpParser extends AbstractParser implements ParserInterface
 {
-    /** @var array<string, mixed> */
+    /** @var array<int|string, mixed> */
     private array $translations = [];
 
     public function __construct(string $filePath)
@@ -124,23 +131,98 @@ class PhpParser extends AbstractParser implements ParserInterface
 
     private function loadTranslations(): void
     {
-        // Temporarily disable error reporting to prevent issues with include
-        $errorReporting = error_reporting(0);
+        $source = file_get_contents($this->filePath);
+        // @codeCoverageIgnoreStart
+        if (false === $source) {
+            throw new RuntimeException('Failed to read PHP translation file');
+        }
+        // @codeCoverageIgnoreEnd
 
-        try {
-            // Use output buffering to catch any output from the included file
-            ob_start();
-            $result = include $this->filePath;
-            ob_end_clean();
+        // Parse the file into an AST instead of executing it via include.
+        // This prevents arbitrary code execution when validating untrusted
+        // translation files (e.g. from third-party packages or pull requests).
+        $ast = (new ParserFactory())->createForHostVersion()->parse($source);
+        // @codeCoverageIgnoreStart
+        if (null === $ast) {
+            throw new RuntimeException('PHP translation file could not be parsed');
+        }
+        // @codeCoverageIgnoreEnd
 
-            if (!is_array($result)) {
-                throw new RuntimeException('PHP translation file must return an array');
+        $return = (new NodeFinder())->findFirstInstanceOf($ast, Return_::class);
+        if (!$return instanceof Return_ || !$return->expr instanceof Array_) {
+            throw new RuntimeException('PHP translation file must return an array');
+        }
+
+        $this->translations = $this->evaluateArray($return->expr);
+    }
+
+    /**
+     * Safely evaluates an array literal node into a PHP array.
+     *
+     * Only scalar literals (string, int, float, bool, null) and nested arrays
+     * are supported. Any other expression (function calls, variables, constants)
+     * is rejected to guarantee no code is executed.
+     *
+     * @return array<int|string, mixed>
+     */
+    private function evaluateArray(Array_ $array): array
+    {
+        $result = [];
+        foreach ($array->items as $item) {
+            if (null === $item->key) {
+                throw new RuntimeException('PHP translation file must use string or integer keys');
             }
 
-            $this->translations = $result;
-        } finally {
-            // Restore error reporting
-            error_reporting($errorReporting);
+            $key = $this->evaluateScalar($item->key);
+            if (!is_string($key) && !is_int($key)) {
+                throw new RuntimeException('PHP translation file must use string or integer keys');
+            }
+
+            $result[$key] = $item->value instanceof Array_
+                ? $this->evaluateArray($item->value)
+                : $this->evaluateScalar($item->value);
         }
+
+        return $result;
+    }
+
+    private function evaluateScalar(Node $node): string|int|float|bool|null
+    {
+        if ($node instanceof String_) {
+            return $node->value;
+        }
+
+        if ($node instanceof Int_) {
+            return $node->value;
+        }
+
+        if ($node instanceof Float_) {
+            return $node->value;
+        }
+
+        if ($node instanceof UnaryMinus) {
+            $operand = $this->evaluateScalar($node->expr);
+            if (is_int($operand) || is_float($operand)) {
+                return -$operand;
+            }
+            throw new RuntimeException('PHP translation file contains an unsupported expression');
+        }
+
+        if ($node instanceof ConstFetch) {
+            $name = strtolower($node->name->toString());
+            if ('true' === $name) {
+                return true;
+            }
+            if ('false' === $name) {
+                return false;
+            }
+            if ('null' === $name) {
+                return null;
+            }
+
+            throw new RuntimeException('PHP translation file contains an unsupported constant');
+        }
+
+        throw new RuntimeException('PHP translation file contains an unsupported expression');
     }
 }

--- a/tests/src/Parser/PhpParserTest.php
+++ b/tests/src/Parser/PhpParserTest.php
@@ -240,6 +240,150 @@ final class PhpParserTest extends TestCase
         }
     }
 
+    public function testDoesNotExecuteCodeInFile(): void
+    {
+        $marker = (tempnam(sys_get_temp_dir(), 'marker_') ?: '').'.marker';
+
+        $tempFile = tempnam(sys_get_temp_dir(), 'malicious_').'.php';
+        file_put_contents(
+            $tempFile,
+            "<?php file_put_contents('".$marker."', 'pwned'); return ['key' => 'value'];",
+        );
+
+        try {
+            $parser = new PhpParser($tempFile);
+
+            $this->assertFileDoesNotExist($marker, 'PHP translation file must not be executed');
+            $this->assertSame('value', $parser->getContentByKey('key'));
+        } finally {
+            unlink($tempFile);
+            if (file_exists($marker)) {
+                unlink($marker);
+            }
+        }
+    }
+
+    public function testRejectsFunctionCallValues(): void
+    {
+        $tempFile = tempnam(sys_get_temp_dir(), 'call_').'.php';
+        file_put_contents($tempFile, "<?php return ['key' => strtoupper('value')];");
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('unsupported expression');
+
+        try {
+            new PhpParser($tempFile);
+        } finally {
+            unlink($tempFile);
+        }
+    }
+
+    public function testRejectsListArrayWithImplicitKeys(): void
+    {
+        $tempFile = tempnam(sys_get_temp_dir(), 'list_').'.php';
+        file_put_contents($tempFile, '<?php return ["a", "b"];');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('string or integer keys');
+
+        try {
+            new PhpParser($tempFile);
+        } finally {
+            unlink($tempFile);
+        }
+    }
+
+    public function testRejectsUnsupportedConstant(): void
+    {
+        $tempFile = tempnam(sys_get_temp_dir(), 'const_').'.php';
+        file_put_contents($tempFile, '<?php return ["key" => PHP_EOL];');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('unsupported constant');
+
+        try {
+            new PhpParser($tempFile);
+        } finally {
+            unlink($tempFile);
+        }
+    }
+
+    public function testRejectsFloatKey(): void
+    {
+        $tempFile = tempnam(sys_get_temp_dir(), 'floatkey_').'.php';
+        file_put_contents($tempFile, '<?php return [1.5 => "value"];');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('string or integer keys');
+
+        try {
+            new PhpParser($tempFile);
+        } finally {
+            unlink($tempFile);
+        }
+    }
+
+    public function testHandlesBooleanFalseValue(): void
+    {
+        $tempFile = tempnam(sys_get_temp_dir(), 'false_').'.php';
+        file_put_contents($tempFile, '<?php return ["flag" => false];');
+
+        try {
+            $parser = new PhpParser($tempFile);
+            $keys = $parser->extractKeys();
+            $this->assertSame(['flag'], $keys);
+        } finally {
+            unlink($tempFile);
+        }
+    }
+
+    public function testRejectsFileWithoutReturn(): void
+    {
+        $tempFile = tempnam(sys_get_temp_dir(), 'noreturn_').'.php';
+        file_put_contents($tempFile, '<?php $x = 1;');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('must return an array');
+
+        try {
+            new PhpParser($tempFile);
+        } finally {
+            unlink($tempFile);
+        }
+    }
+
+    public function testRejectsNegatedNonNumber(): void
+    {
+        $tempFile = tempnam(sys_get_temp_dir(), 'negstr_').'.php';
+        file_put_contents($tempFile, '<?php return ["key" => -"x"];');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('unsupported expression');
+
+        try {
+            new PhpParser($tempFile);
+        } finally {
+            unlink($tempFile);
+        }
+    }
+
+    public function testHandlesNegativeNumbers(): void
+    {
+        $tempFile = tempnam(sys_get_temp_dir(), 'negative_').'.php';
+        file_put_contents($tempFile, '<?php return ["count" => -5, "ratio" => -1.5];');
+
+        try {
+            $parser = new PhpParser($tempFile);
+
+            $keys = $parser->extractKeys();
+            $this->assertIsArray($keys);
+            $this->assertContains('count', $keys);
+            $this->assertContains('ratio', $keys);
+        } finally {
+            unlink($tempFile);
+        }
+    }
+
     public function testHandlesEmptyArray(): void
     {
         $tempFile = tempnam(sys_get_temp_dir(), 'empty_').'.php';


### PR DESCRIPTION
## Summary

- Fixes a critical remote code execution vector: `PhpParser` previously loaded PHP translation files via `include`, executing the entire file body before checking the return value. Any `*.php` file in a scanned directory (e.g. from a third-party package or a pull request) was executed.
- PHP translation files are now parsed into an AST via `nikic/php-parser`. Only a top-level `return` of an array literal built from scalar values (string, int, float, bool, null) and nested arrays is evaluated. Function calls, variables and constants are rejected — no code is executed.

## Changes

- `src/Parser/PhpParser.php` — replace `include` with AST parsing and a safe recursive array/scalar evaluator
- `tests/src/Parser/PhpParserTest.php` — add tests proving file code is not executed, function-call values are rejected, and negative numbers are handled
- `composer.json` / `composer.lock` — add `nikic/php-parser` as a runtime dependency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PHP translation loading to safely extract values from returned arrays without executing embedded code.
  * Negative numbers and nested arrays are supported.
  * Invalid translation expressions and unsupported structures (e.g., function calls, non-array returns, implicit keys, float keys, unsupported constants) are rejected with clearer errors; boolean `false` handling is corrected.
* **Chores**
  * Updated runtime dependencies to support safer translation parsing.
* **Tests**
  * Added coverage to confirm no code execution and to validate the above input constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->