### PR TITLE
fix: exclude PHP config files from auto-detection

### DIFF
--- a/docs/configuration/config-file.md
+++ b/docs/configuration/config-file.md
@@ -214,7 +214,8 @@ You can also specify the path to a configuration file in your `composer.json`:
 
 The plugin automatically searches for configuration files in this order:
 
-1. `translation-validator.php`
-2. `translation-validator.json`
-3. `translation-validator.yaml`
-4. `translation-validator.yml`
+1. `translation-validator.json`
+2. `translation-validator.yaml`
+3. `translation-validator.yml`
+
+PHP configuration files are **not** auto-detected, because they are executed when loaded. To use one, reference it explicitly via the `--config` option or the `composer.json` `config-file` entry.

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -43,12 +43,13 @@ Specify a custom configuration file path in `composer.json`:
 
 The plugin automatically searches for configuration files in this order:
 
-1. `translation-validator.php`
-2. `translation-validator.json`
-3. `translation-validator.yaml`
-4. `translation-validator.yml`
+1. `translation-validator.json`
+2. `translation-validator.yaml`
+3. `translation-validator.yml`
 
 The first file found will be used.
+
+PHP configuration files are **not** auto-detected, because they are executed when loaded. Auto-loading one from an untrusted working directory would allow arbitrary code execution. To use a PHP configuration file, reference it explicitly via the `--config` option or the `composer.json` `config-file` entry.
 
 ## Configuration Priority
 

--- a/src/Config/ConfigReader.php
+++ b/src/Config/ConfigReader.php
@@ -26,8 +26,13 @@ use function is_array;
  */
 class ConfigReader
 {
+    /**
+     * PHP config files are intentionally excluded from auto-detection: they are
+     * executed via `require`, so auto-loading one found in an untrusted working
+     * directory would allow arbitrary code execution. A PHP config must be opted
+     * into explicitly via the `--config` option.
+     */
     private const AUTO_DETECTION_FILES = [
-        'translation-validator.php',
         'translation-validator.json',
         'translation-validator.yaml',
         'translation-validator.yml',

--- a/tests/src/Config/ConfigReaderTest.php
+++ b/tests/src/Config/ConfigReaderTest.php
@@ -130,12 +130,22 @@ final class ConfigReaderTest extends TestCase
         rmdir($emptyDir);
     }
 
-    public function testAutoDetectWithPhpFile(): void
+    public function testAutoDetectIgnoresPhpFile(): void
     {
-        $config = $this->configReader->autoDetect($this->fixturesDir.'/auto-detect');
-        $this->assertInstanceOf(TranslationValidatorConfig::class, $config);
+        // A directory containing only a PHP config must not be auto-detected,
+        // since auto-loading (and thereby executing) it would allow arbitrary
+        // code execution in an untrusted working directory.
+        $tempDir = sys_get_temp_dir().'/translation-validator-php-'.uniqid('', true);
+        mkdir($tempDir, 0777, true);
+        copy($this->fixturesDir.'/auto-detect/translation-validator.php', $tempDir.'/translation-validator.php');
 
-        $this->assertSame(['detected-php'], $config->getPaths());
+        try {
+            $config = $this->configReader->autoDetect($tempDir);
+            $this->assertNull($config);
+        } finally {
+            unlink($tempDir.'/translation-validator.php');
+            rmdir($tempDir);
+        }
     }
 
     public function testAutoDetectWithJsonFile(): void
@@ -160,8 +170,8 @@ final class ConfigReaderTest extends TestCase
         $config = $this->configReader->autoDetect($this->fixturesDir.'/auto-detect');
         $this->assertInstanceOf(TranslationValidatorConfig::class, $config);
 
-        // Should pick PHP first (highest priority)
-        $this->assertSame(['detected-php'], $config->getPaths());
+        // PHP is excluded from auto-detection, so JSON has the highest priority.
+        $this->assertSame(['detected-json'], $config->getPaths());
     }
 
     public function testReadFromComposerJsonNotFound(): void


### PR DESCRIPTION
## Summary

- PHP configuration files (`translation-validator.php`) are executed via `require` when loaded. Auto-detection previously picked them up from the working directory automatically, so running the tool inside an untrusted project (e.g. a cloned repo or PR branch) could execute arbitrary code without any explicit opt-in.
- PHP config files are now excluded from auto-detection. JSON and YAML (declarative, non-executable) remain auto-detected. A PHP config can still be used, but only when referenced explicitly via `--config` or the `composer.json` `config-file` entry — a deliberate developer choice.

## Changes

- `src/Config/ConfigReader.php` — drop `translation-validator.php` from the auto-detection list
- `tests/src/Config/ConfigReaderTest.php` — assert a PHP-only directory is not auto-detected; update priority test to JSON
- `docs/configuration/index.md`, `docs/configuration/config-file.md` — document the exclusion and rationale