### PR TITLE
fix: reject invalid validator classes in --only/--skip options

### DIFF
--- a/src/Command/ValidateTranslationCommand.php
+++ b/src/Command/ValidateTranslationCommand.php
@@ -191,16 +191,31 @@ HELP
             return Command::FAILURE;
         }
 
+        $onlyOption = $input->getOption('only');
+        $skipOption = $input->getOption('skip');
+
         $onlyValidators = $this->orchestrationService->validateClassInput(
             ValidatorInterface::class,
             'validator',
-            $input->getOption('only'),
+            $onlyOption,
         );
         $skipValidators = $this->orchestrationService->validateClassInput(
             ValidatorInterface::class,
             'validator',
-            $input->getOption('skip'),
+            $skipOption,
         );
+
+        if (!empty($onlyOption) && empty($onlyValidators)) {
+            $this->io?->error('The "--only" option contains no valid validators.');
+
+            return Command::FAILURE;
+        }
+
+        if (!empty($skipOption) && empty($skipValidators)) {
+            $this->io?->error('The "--skip" option contains no valid validators.');
+
+            return Command::FAILURE;
+        }
 
         $validators = $this->orchestrationService->resolveValidators($onlyValidators, $skipValidators, $config);
 

--- a/src/Service/ValidationOrchestrationService.php
+++ b/src/Service/ValidationOrchestrationService.php
@@ -149,15 +149,13 @@ class ValidationOrchestrationService
         $classes = [];
 
         foreach ($classNames as $name) {
-            ClassUtility::instantiate(
-                $interface,
-                $this->logger,
-                $type,
-                $name,
-            );
-            /** @var class-string<T> $validatedName */
-            $validatedName = $name;
-            $classes[] = $validatedName;
+            if (!ClassUtility::validateClass($interface, $this->logger, $name)) {
+                continue;
+            }
+
+            /** @var class-string<T> $validated */
+            $validated = $name;
+            $classes[] = $validated;
         }
 
         return $classes;

--- a/tests/src/Command/ValidateTranslationCommandTest.php
+++ b/tests/src/Command/ValidateTranslationCommandTest.php
@@ -20,7 +20,6 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
-use Throwable;
 
 #[CoversClass(ValidateTranslationCommand::class)]
 /**
@@ -89,18 +88,36 @@ final class ValidateTranslationCommandTest extends TestCase
         $command = $application->find('validate-translations');
         $commandTester = new CommandTester($command);
 
-        try {
-            $commandTester->execute([
-                'path' => [__DIR__.'/../Fixtures/translations/xliff/success'],
-                '--only' => 'Invalid\\Validator\\Class',
-            ]);
-            $this->fail('Expected exception was not thrown.');
-        } catch (Throwable $e) {
-            $this->assertStringContainsString(
-                'Class "Invalid\Validator\Class" not found',
-                $e->getMessage(),
-            );
-        }
+        $commandTester->execute([
+            'path' => [__DIR__.'/../Fixtures/translations/xliff/success'],
+            '--only' => 'Invalid\\Validator\\Class',
+        ]);
+
+        $this->assertSame(Command::FAILURE, $commandTester->getStatusCode());
+        $this->assertStringContainsString(
+            'The "--only" option contains no valid validators.',
+            $commandTester->getDisplay(),
+        );
+    }
+
+    public function testExecuteWithInvalidSkipValidator(): void
+    {
+        $application = new Application();
+        $this->addCommandToApplication($application, new ValidateTranslationCommand());
+
+        $command = $application->find('validate-translations');
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute([
+            'path' => [__DIR__.'/../Fixtures/translations/xliff/success'],
+            '--skip' => 'Invalid\\Validator\\Class',
+        ]);
+
+        $this->assertSame(Command::FAILURE, $commandTester->getStatusCode());
+        $this->assertStringContainsString(
+            'The "--skip" option contains no valid validators.',
+            $commandTester->getDisplay(),
+        );
     }
 
     public function testExecuteWithErrors(): void

--- a/tests/src/Service/ValidationOrchestrationServiceTest.php
+++ b/tests/src/Service/ValidationOrchestrationServiceTest.php
@@ -285,14 +285,25 @@ final class ValidationOrchestrationServiceTest extends TestCase
 
     public function testValidateClassInputWithInvalidClass(): void
     {
-        // Invalid classes are logged as errors but still returned in the array
-        // This matches the original behavior from ValidateTranslationCommand
+        // Invalid classes are logged as errors and excluded from the result,
+        // so they never reach the validator chain.
         $result = $this->service->validateClassInput(
             ValidatorInterface::class,
             'validator',
             'NonExistentValidator',
         );
 
-        $this->assertSame(['NonExistentValidator'], $result);
+        $this->assertSame([], $result);
+    }
+
+    public function testValidateClassInputMixesValidAndInvalidClasses(): void
+    {
+        $result = $this->service->validateClassInput(
+            ValidatorInterface::class,
+            'validator',
+            MismatchValidator::class.',NonExistentValidator',
+        );
+
+        $this->assertSame([MismatchValidator::class], $result);
     }
 }


### PR DESCRIPTION
## Summary

- `validateClassInput()` previously ignored the result of the class validation and added every provided name to the validator list, even non-existent classes or classes not implementing `ValidatorInterface`. Invalid FQCNs then reached the validator chain and failed later with an opaque error.
- Invalid classes are now filtered out during input validation. When an explicitly provided `--only` or `--skip` option contains no valid validator at all, the command now fails fast with a clear message instead of silently running all validators or crashing deep in the chain.

## Changes

- `src/Service/ValidationOrchestrationService.php` — gate the validator list on `ClassUtility::validateClass()` instead of a discarded `instantiate()` call
- `src/Command/ValidateTranslationCommand.php` — fail with a clear error when `--only`/`--skip` yields no valid validators
- `tests/src/Service/ValidationOrchestrationServiceTest.php` — invalid classes are excluded; add a mixed valid/invalid case
- `tests/src/Command/ValidateTranslationCommandTest.php` — assert the clear failure for an invalid `--only`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved translation validation when using validator filters.
  * Invalid entries supplied to `--only` or `--skip` now produce a clear error and fail gracefully.
  * Invalid validator classes are ignored instead of causing unexpected processing errors.
  * Mixed valid and invalid validator inputs now process only the valid entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->