### PR TITLE
fix: do not follow symlinks during recursive file scan

### DIFF
--- a/src/FileDetector/Collector.php
+++ b/src/FileDetector/Collector.php
@@ -16,9 +16,11 @@ namespace MoveElevator\ComposerTranslationValidator\FileDetector;
 use Exception;
 use MoveElevator\ComposerTranslationValidator\Parser\ParserRegistry;
 use Psr\Log\LoggerInterface;
+use RecursiveCallbackFilterIterator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use ReflectionException;
+use SplFileInfo;
 use Symfony\Component\Filesystem\Filesystem;
 
 use function dirname;
@@ -140,8 +142,15 @@ class Collector
         $files = [];
 
         try {
+            // Reject symlinks (files and directories) so the recursive scan
+            // cannot be redirected outside the target tree via a crafted link.
+            $directoryIterator = new RecursiveDirectoryIterator($normalizedPath, RecursiveDirectoryIterator::SKIP_DOTS);
+            $filteredIterator = new RecursiveCallbackFilterIterator(
+                $directoryIterator,
+                static fn (SplFileInfo $current): bool => !$current->isLink(),
+            );
             $iterator = new RecursiveIteratorIterator(
-                new RecursiveDirectoryIterator($normalizedPath, RecursiveDirectoryIterator::SKIP_DOTS),
+                $filteredIterator,
                 RecursiveIteratorIterator::LEAVES_ONLY,
             );
 

--- a/tests/src/FileDetector/CollectorTest.php
+++ b/tests/src/FileDetector/CollectorTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 use function count;
+use function function_exists;
 use function in_array;
 
 /**
@@ -146,6 +147,49 @@ final class CollectorTest extends TestCase
 
         $this->assertArrayHasKey(XliffParser::class, $result);
         $this->assertEquals(['recursive_data'], $result[XliffParser::class][$this->tempDir]);
+    }
+
+    public function testCollectFilesDoesNotFollowSymlinks(): void
+    {
+        if (!function_exists('symlink')) {
+            $this->markTestSkipped('symlink() is not available on this platform.');
+        }
+
+        // Target directory lives outside the scanned tree and is only reachable
+        // through the symlink created below.
+        $outside = sys_get_temp_dir().'/collector_outside_'.uniqid('', true);
+        mkdir($outside);
+        file_put_contents($outside.'/secret.xlf', 'secret content');
+
+        file_put_contents($this->tempDir.'/real.xlf', 'real content');
+        if (!@symlink($outside, $this->tempDir.'/link')) {
+            unlink($outside.'/secret.xlf');
+            rmdir($outside);
+            $this->markTestSkipped('Unable to create a symlink on this platform.');
+        }
+
+        $captured = [];
+        $detector = $this->createStub(DetectorInterface::class);
+        $detector->method('mapTranslationSet')->willReturnCallback(
+            static function (array $files) use (&$captured): array {
+                $captured = array_merge($captured, $files);
+
+                return ['data'];
+            },
+        );
+
+        try {
+            $collector = new Collector($this->createStub(LoggerInterface::class));
+            $collector->collectFiles([$this->tempDir], $detector, null, true);
+
+            $joined = implode('|', $captured);
+            $this->assertStringContainsString('real.xlf', $joined);
+            $this->assertStringNotContainsString('secret.xlf', $joined);
+        } finally {
+            unlink($this->tempDir.'/link');
+            unlink($outside.'/secret.xlf');
+            rmdir($outside);
+        }
     }
 
     public function testCollectFilesWithMultipleFileTypes(): void


### PR DESCRIPTION
## Summary

- The recursive file scan used a `RecursiveDirectoryIterator` that descends into symlinked directories. A crafted symlink inside an otherwise harmless directory could redirect the scan (and thereby the parsers) to files outside the target tree.
- Symlinks (both files and directories) are now rejected during the recursive scan via a `RecursiveCallbackFilterIterator`, so the scan stays within the intended directory tree.

## Changes

- `src/FileDetector/Collector.php` — filter out symlinks before recursing
- `tests/src/FileDetector/CollectorTest.php` — assert a file only reachable through a symlink is not collected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - File discovery no longer follows symbolic links during recursive scans.
  - Scans remain within the intended directory and avoid collecting files located outside it.

- **Tests**
  - Added coverage to verify symbolic links are ignored during file collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->