### PR TITLE
fix: harden system path safety check with boundary matching

### DIFF
--- a/src/FileDetector/Collector.php
+++ b/src/FileDetector/Collector.php
@@ -181,18 +181,29 @@ class Collector
 
     /**
      * Basic path safety check to prevent obvious security issues.
+     *
+     * Rejects sensitive system locations. Matching is done on path boundaries
+     * (so `/etc` does not reject `/etcetera`) and case-insensitively to also
+     * cover Windows system directories.
      */
     private function isPathSafe(string $path): bool
     {
-        $dangerousPaths = ['/etc', '/usr', '/bin', '/sbin', '/proc', '/sys', '/private/etc'];
+        $normalized = rtrim(str_replace('\\', '/', $path), '/');
+        $haystack = strtolower($normalized).'/';
+
+        $dangerousPaths = [
+            '/etc', '/usr', '/bin', '/sbin', '/proc', '/sys', '/dev', '/root', '/boot',
+            '/private/etc',
+            'c:/windows', 'c:/program files', 'c:/program files (x86)',
+        ];
 
         foreach ($dangerousPaths as $dangerousPath) {
-            if (str_starts_with($path, $dangerousPath)) {
+            if (str_starts_with($haystack, $dangerousPath.'/')) {
                 return false;
             }
         }
 
-        return substr_count($path, '/') + substr_count($path, '\\') <= 20;
+        return substr_count($normalized, '/') <= 20;
     }
 
     /**

--- a/tests/src/FileDetector/CollectorTest.php
+++ b/tests/src/FileDetector/CollectorTest.php
@@ -247,6 +247,25 @@ final class CollectorTest extends TestCase
         $this->assertSame([], $result);
     }
 
+    public function testCollectFilesSkipsAdditionalSystemPaths(): void
+    {
+        if (!is_dir('/dev')) {
+            $this->markTestSkipped('/dev is not available on this platform.');
+        }
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->atLeastOnce())
+            ->method('warning')
+            ->with($this->stringContains('Skipping potentially unsafe path'));
+
+        $detector = $this->createStub(DetectorInterface::class);
+        $collector = new Collector($logger);
+
+        $result = $collector->collectFiles(['/dev'], $detector, null, true);
+
+        $this->assertSame([], $result);
+    }
+
     private function removeDirectory(string $path): void
     {
         $files = glob($path.'/*');


### PR DESCRIPTION
## Summary

- The recursive-scan path safety check used a plain prefix denylist, which both produced false positives (e.g. `/etc` rejected `/etcetera`) and missed several sensitive locations.
- Matching now happens on path boundaries and case-insensitively, and the denylist additionally covers `/dev`, `/root`, `/boot` and Windows system directories. Common project locations (`/var/www`, `/home/...`) remain scannable.

## Changes

- `src/FileDetector/Collector.php` — boundary-aware, case-insensitive denylist with additional system roots
- `tests/src/FileDetector/CollectorTest.php` — assert a newly covered system path (`/dev`) is skipped