### PR TITLE
fix: strip control characters and escape markup in CLI output

### DIFF
--- a/src/Utility/OutputUtility.php
+++ b/src/Utility/OutputUtility.php
@@ -39,4 +39,16 @@ class OutputUtility
 
         $newLine ? $output->writeln($message) : $output->write($message);
     }
+
+    /**
+     * Removes control characters (except tab and newline) from a string.
+     *
+     * Untrusted translation values may contain raw ANSI escape sequences; if
+     * rendered verbatim they could manipulate the terminal. Stripping control
+     * characters neutralises that before the value reaches the console.
+     */
+    public static function stripControlCharacters(string $value): string
+    {
+        return preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/', '', $value) ?? $value;
+    }
 }

--- a/src/Utility/OutputUtility.php
+++ b/src/Utility/OutputUtility.php
@@ -49,6 +49,6 @@ class OutputUtility
      */
     public static function stripControlCharacters(string $value): string
     {
-        return preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/', '', $value) ?? $value;
+        return preg_replace('/[\x00-\x08\x0B-\x1F\x7F]/', '', $value) ?? $value;
     }
 }

--- a/src/Validator/HtmlTagValidator.php
+++ b/src/Validator/HtmlTagValidator.php
@@ -15,6 +15,7 @@ namespace MoveElevator\ComposerTranslationValidator\Validator;
 
 use MoveElevator\ComposerTranslationValidator\Parser\{JsonParser, ParserInterface, PhpParser, XliffParser, YamlParser};
 use MoveElevator\ComposerTranslationValidator\Result\Issue;
+use MoveElevator\ComposerTranslationValidator\Utility\OutputUtility;
 use MoveElevator\ComposerTranslationValidator\Validator\Trait\DistributesIssuesForDisplayTrait;
 use Symfony\Component\Console\Helper\{Table, TableStyle};
 use Symfony\Component\Console\Output\OutputInterface;
@@ -353,6 +354,7 @@ class HtmlTagValidator extends AbstractValidator implements ValidatorInterface
 
     private function highlightHtmlTags(string $value): string
     {
+        $value = OutputUtility::stripControlCharacters($value);
         $value = preg_replace('/<(\w+)([^>]*)>/', '<fg=cyan><$1$2></>', $value) ?? $value;
 
         return preg_replace('/<\/(\w+)>/', '<fg=magenta></$1></>', $value) ?? $value;

--- a/src/Validator/PlaceholderConsistencyValidator.php
+++ b/src/Validator/PlaceholderConsistencyValidator.php
@@ -15,7 +15,9 @@ namespace MoveElevator\ComposerTranslationValidator\Validator;
 
 use MoveElevator\ComposerTranslationValidator\Parser\{JsonParser, ParserInterface, PhpParser, XliffParser, YamlParser};
 use MoveElevator\ComposerTranslationValidator\Result\Issue;
+use MoveElevator\ComposerTranslationValidator\Utility\OutputUtility;
 use MoveElevator\ComposerTranslationValidator\Validator\Trait\DistributesIssuesForDisplayTrait;
+use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Helper\{Table, TableStyle};
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -295,6 +297,12 @@ class PlaceholderConsistencyValidator extends AbstractValidator implements Valid
     private function highlightPlaceholders(string $value): string
     {
         $placeholders = $this->extractPlaceholders($value);
+
+        // Neutralise control characters and console markup in the raw value so
+        // untrusted content cannot inject terminal escapes or formatter tags.
+        // Placeholder tokens contain no markup characters, so escaping the value
+        // leaves them intact for the highlighting below.
+        $value = OutputFormatter::escape(OutputUtility::stripControlCharacters($value));
 
         foreach ($placeholders as $placeholder) {
             $value = str_replace($placeholder, "<fg=yellow>{$placeholder}</>", $value);

--- a/tests/src/Utility/OutputUtilityTest.php
+++ b/tests/src/Utility/OutputUtilityTest.php
@@ -81,4 +81,23 @@ final class OutputUtilityTest extends TestCase
 
         OutputUtility::debug($output, 'Test message', false, false);
     }
+
+    public function testStripControlCharactersRemovesAnsiEscapes(): void
+    {
+        $input = "before\x1b[31mred\x1b[0mafter";
+
+        $this->assertSame('before[31mred[0mafter', OutputUtility::stripControlCharacters($input));
+    }
+
+    public function testStripControlCharactersRemovesNullAndDelete(): void
+    {
+        $this->assertSame('clean', OutputUtility::stripControlCharacters("cl\x00ea\x7fn"));
+    }
+
+    public function testStripControlCharactersKeepsTabAndNewline(): void
+    {
+        $input = "line1\nline2\tend";
+
+        $this->assertSame($input, OutputUtility::stripControlCharacters($input));
+    }
 }

--- a/tests/src/Utility/OutputUtilityTest.php
+++ b/tests/src/Utility/OutputUtilityTest.php
@@ -100,4 +100,9 @@ final class OutputUtilityTest extends TestCase
 
         $this->assertSame($input, OutputUtility::stripControlCharacters($input));
     }
+
+    public function testStripControlCharactersRemovesCarriageReturn(): void
+    {
+        $this->assertSame('safeDANGER', OutputUtility::stripControlCharacters("safe\rDANGER"));
+    }
 }


### PR DESCRIPTION
## Summary

- Translation values are rendered into the CLI output (placeholder and HTML-tag highlighting). Untrusted values could contain raw ANSI escape sequences (terminal manipulation) or Symfony Console markup that the formatter would interpret.
- Control characters (except tab and newline) are now stripped from values before display, and the placeholder highlighter additionally escapes console markup while keeping placeholder highlighting intact.

## Changes

- `src/Utility/OutputUtility.php` — add `stripControlCharacters()` helper
- `src/Validator/HtmlTagValidator.php` — strip control characters before highlighting tags
- `src/Validator/PlaceholderConsistencyValidator.php` — strip control characters and escape markup before highlighting placeholders
- `tests/src/Utility/OutputUtilityTest.php` — cover ANSI/NUL/DEL removal and tab/newline preservation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of untrusted text in console output by removing control characters before formatting.
  * Reduced the risk of unexpected terminal styling or markup issues in highlighted validation results.

* **Tests**
  * Added coverage for control-character filtering, including ANSI sequences and hidden characters.
  * Verified that tabs and newlines are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->