### PR TITLE
fix: skip translation files exceeding a size limit

### DIFF
--- a/src/FileDetector/Collector.php
+++ b/src/FileDetector/Collector.php
@@ -22,7 +22,9 @@ use ReflectionException;
 use Symfony\Component\Filesystem\Filesystem;
 
 use function dirname;
+use function filesize;
 use function in_array;
+use function sprintf;
 
 /**
  * Collector.
@@ -32,6 +34,13 @@ use function in_array;
  */
 class Collector
 {
+    /**
+     * Maximum size (in bytes) of a translation file that will be read into
+     * memory. Larger files are skipped to prevent memory exhaustion when
+     * scanning untrusted directories.
+     */
+    private const MAX_FILE_SIZE = 30 * 1024 * 1024;
+
     public function __construct(protected ?LoggerInterface $logger = null) {}
 
     /**
@@ -122,11 +131,11 @@ class Collector
 
             return array_filter(
                 $globFiles,
-                static fn ($file) => in_array(
+                fn ($file) => in_array(
                     pathinfo((string) $file, \PATHINFO_EXTENSION),
                     $supportedExtensions,
                     true,
-                ),
+                ) && $this->isWithinSizeLimit((string) $file),
             );
         }
 
@@ -149,7 +158,9 @@ class Collector
                 $filePath = $file->getPathname();
                 $extension = pathinfo((string) $filePath, \PATHINFO_EXTENSION);
 
-                if (in_array($extension, $supportedExtensions, true) && is_file($filePath)) {
+                if (in_array($extension, $supportedExtensions, true)
+                    && is_file($filePath)
+                    && $this->isWithinSizeLimit($filePath)) {
                     $files[] = $filePath;
                 }
             }
@@ -162,6 +173,24 @@ class Collector
         // @codeCoverageIgnoreEnd
 
         return $files;
+    }
+
+    /**
+     * Rejects files larger than the configured limit to avoid loading huge
+     * (potentially malicious) files entirely into memory.
+     */
+    private function isWithinSizeLimit(string $file): bool
+    {
+        $size = filesize($file);
+        if (false !== $size && $size > self::MAX_FILE_SIZE) {
+            $this->logger?->warning(
+                sprintf('Skipping file exceeding the maximum size of %d bytes: %s', self::MAX_FILE_SIZE, $file),
+            );
+
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/src/FileDetector/Collector.php
+++ b/src/FileDetector/Collector.php
@@ -182,7 +182,17 @@ class Collector
     private function isWithinSizeLimit(string $file): bool
     {
         $size = filesize($file);
-        if (false !== $size && $size > self::MAX_FILE_SIZE) {
+        // @codeCoverageIgnoreStart
+        if (false === $size) {
+            $this->logger?->warning(
+                sprintf('Unable to determine file size, skipping: %s', $file),
+            );
+
+            return false;
+        }
+        // @codeCoverageIgnoreEnd
+
+        if ($size > self::MAX_FILE_SIZE) {
             $this->logger?->warning(
                 sprintf('Skipping file exceeding the maximum size of %d bytes: %s', self::MAX_FILE_SIZE, $file),
             );

--- a/tests/src/FileDetector/CollectorTest.php
+++ b/tests/src/FileDetector/CollectorTest.php
@@ -247,6 +247,44 @@ final class CollectorTest extends TestCase
         $this->assertSame([], $result);
     }
 
+    public function testCollectFilesSkipsOversizedFiles(): void
+    {
+        file_put_contents($this->tempDir.'/small.xlf', 'content');
+
+        // Create a sparse file larger than the 30 MB limit without actually
+        // writing 30 MB of data.
+        $big = $this->tempDir.'/big.xlf';
+        $handle = fopen($big, 'w');
+        if (false === $handle) {
+            $this->markTestSkipped('Unable to create the oversized test file.');
+        }
+        fseek($handle, 30 * 1024 * 1024);
+        fwrite($handle, 'x');
+        fclose($handle);
+
+        $captured = [];
+        $detector = $this->createStub(DetectorInterface::class);
+        $detector->method('mapTranslationSet')->willReturnCallback(
+            static function (array $files) use (&$captured): array {
+                $captured = array_merge($captured, $files);
+
+                return ['data'];
+            },
+        );
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->atLeastOnce())
+            ->method('warning')
+            ->with($this->stringContains('exceeding the maximum size'));
+
+        $collector = new Collector($logger);
+        $collector->collectFiles([$this->tempDir], $detector, null);
+
+        $joined = implode('|', $captured);
+        $this->assertStringContainsString('small.xlf', $joined);
+        $this->assertStringNotContainsString('big.xlf', $joined);
+    }
+
     private function removeDirectory(string $path): void
     {
         $files = glob($path.'/*');


### PR DESCRIPTION
## Summary

- Parsers read entire files into memory with `file_get_contents` and no upper bound, so a very large (or sparsely inflated) translation file could exhaust memory when scanning untrusted directories.
- The collector now skips files larger than 30 MB and logs a warning, so oversized files never reach the parsers.

## Changes

- `src/FileDetector/Collector.php` — add a `MAX_FILE_SIZE` guard applied in both the recursive and non-recursive scan paths
- `tests/src/FileDetector/CollectorTest.php` — assert an oversized (sparse) file is skipped while a normal file is still collected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Translation files larger than 30 MB are now skipped during file collection.
  * A warning is logged when an oversized translation file is detected.
  * Normal-sized translation files continue to be processed as expected.

* **Tests**
  * Added a PHPUnit test to verify oversized translation files are excluded while smaller files are still collected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->