### PR TITLE
fix: reject DOCTYPE and disable network in XLIFF parser

### DIFF
--- a/src/Parser/XliffParser.php
+++ b/src/Parser/XliffParser.php
@@ -47,8 +47,14 @@ class XliffParser extends AbstractParser implements ParserInterface
         }
         // @codeCoverageIgnoreEnd
 
+        // Reject document type definitions outright and disable network access
+        // during parsing as defense-in-depth against XXE / entity-expansion.
+        if (preg_match('/<!DOCTYPE/i', $xmlContent)) {
+            throw new InvalidArgumentException("Document type definitions are not allowed in file: {$filePath}");
+        }
+
         libxml_use_internal_errors(true);
-        $this->xml = simplexml_load_string($xmlContent);
+        $this->xml = simplexml_load_string($xmlContent, SimpleXMLElement::class, \LIBXML_NONET);
 
         if (false === $this->xml) {
             throw new InvalidArgumentException("Failed to parse XML content from file: {$filePath}");

--- a/tests/src/Parser/XliffParserTest.php
+++ b/tests/src/Parser/XliffParserTest.php
@@ -311,6 +311,27 @@ EOT;
         new XliffParser($invalidXmlFile);
     }
 
+    public function testConstructorRejectsDoctype(): void
+    {
+        $doctypeFile = $this->tempDir.'/doctype.xlf';
+        $doctypeContent = <<<'EOT'
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE xliff [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" datatype="plaintext" original="doctype.xlf">
+    <body>
+      <trans-unit id="key"><source>&xxe;</source></trans-unit>
+    </body>
+  </file>
+</xliff>
+EOT;
+        file_put_contents($doctypeFile, $doctypeContent);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Document type definitions are not allowed');
+        new XliffParser($doctypeFile);
+    }
+
     public function testGetContentByKeyFallsBackToTargetWhenSourceIsEmpty(): void
     {
         $fallbackFile = $this->tempDir.'/fallback.xlf';


### PR DESCRIPTION
## Summary

- The XLIFF parser did not explicitly reject document type definitions. While external entity loading is disabled by default on PHP 8, this adds defense-in-depth consistent with the schema validator.
- The parser now rejects any file containing a `<!DOCTYPE` declaration and parses with `LIBXML_NONET` to disable network access during parsing.

## Changes

- `src/Parser/XliffParser.php` — reject DOCTYPE declarations and pass `LIBXML_NONET`
- `tests/src/Parser/XliffParserTest.php` — assert an XLIFF file with a DOCTYPE (XXE payload) is rejected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved XLIFF/XML parsing safety by rejecting documents that contain a `DOCTYPE` declaration.
  * Prevented external network access during XML loading, reducing the risk of unsafe or unexpected document handling.

* **Tests**
  * Added coverage to verify that files with `DOCTYPE` declarations are rejected with an appropriate error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->