### PR TITLE
perf: resolve XLIFF content via a memoized id map

### DIFF
--- a/src/Parser/XliffParser.php
+++ b/src/Parser/XliffParser.php
@@ -30,6 +30,9 @@ class XliffParser extends AbstractParser implements ParserInterface
     private readonly SimpleXMLElement|bool $xml;
     private readonly bool $isVersion2;
 
+    /** @var array<string, string>|null Lazily built map of translation-unit id to its resolved content. */
+    private ?array $contentMap = null;
+
     /**
      * @param string $filePath Path to the XLIFF file
      *
@@ -78,33 +81,7 @@ class XliffParser extends AbstractParser implements ParserInterface
 
     public function getContentByKey(string $key): ?string
     {
-        $units = $this->getTranslationUnits();
-        if (null === $units) {
-            return null;
-        }
-
-        $attribute = $this->hasTargetLanguage() ? 'target' : 'source';
-
-        foreach ($units as $unit) {
-            if ((string) $unit['id'] !== $key) {
-                continue;
-            }
-
-            $source = $this->getUnitContent($unit, 'source');
-            $target = $this->getUnitContent($unit, 'target');
-
-            $primary = 'target' === $attribute ? $target : $source;
-            if ('' !== $primary) {
-                return $primary;
-            }
-
-            $fallback = 'target' === $attribute ? $source : $target;
-            if ('' !== $fallback) {
-                return $fallback;
-            }
-        }
-
-        return null;
+        return $this->getContentMap()[$key] ?? null;
     }
 
     /**
@@ -183,6 +160,48 @@ class XliffParser extends AbstractParser implements ParserInterface
             : (string) ($this->xml->file['target-language'] ?? '');
 
         return '' === $lang ? null : $lang;
+    }
+
+    /**
+     * Builds (once) a map of translation-unit id to its resolved content.
+     *
+     * This replaces a linear scan per lookup, which made repeated lookups over
+     * all keys O(n²) per file. The first unit for a given id that yields
+     * non-empty content wins, preserving the previous fallback semantics.
+     *
+     * @return array<string, string>
+     */
+    private function getContentMap(): array
+    {
+        if (null !== $this->contentMap) {
+            return $this->contentMap;
+        }
+
+        $map = [];
+        $units = $this->getTranslationUnits();
+
+        if (null !== $units) {
+            $useTarget = $this->hasTargetLanguage();
+
+            foreach ($units as $unit) {
+                $id = (string) $unit['id'];
+                if (isset($map[$id])) {
+                    continue;
+                }
+
+                $source = $this->getUnitContent($unit, 'source');
+                $target = $this->getUnitContent($unit, 'target');
+
+                $primary = $useTarget ? $target : $source;
+                $value = '' !== $primary ? $primary : ($useTarget ? $source : $target);
+
+                if ('' !== $value) {
+                    $map[$id] = $value;
+                }
+            }
+        }
+
+        return $this->contentMap = $map;
     }
 
     private function getSourceLanguage(): string

--- a/tests/src/Parser/XliffParserTest.php
+++ b/tests/src/Parser/XliffParserTest.php
@@ -225,6 +225,30 @@ EOT;
         $this->assertNull($parser->getContentByKey('nonexistent_key'));
     }
 
+    public function testGetContentByKeyReturnsNullWhenSourceAndTargetEmpty(): void
+    {
+        $emptyFile = $this->tempDir.'/empty.xlf';
+        $emptyContent = <<<'EOT'
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" datatype="plaintext" original="empty.xlf">
+    <body>
+      <trans-unit id="empty"><source></source><target></target></trans-unit>
+      <trans-unit id="filled"><source>Value</source></trans-unit>
+    </body>
+  </file>
+</xliff>
+EOT;
+        file_put_contents($emptyFile, $emptyContent);
+
+        $parser = new XliffParser($emptyFile);
+
+        $this->assertNull($parser->getContentByKey('empty'));
+        $this->assertSame('Value', $parser->getContentByKey('filled'));
+        // Repeated lookups hit the memoized map and stay consistent.
+        $this->assertSame('Value', $parser->getContentByKey('filled'));
+    }
+
     public function testGetSupportedFileExtensions(): void
     {
         $extensions = XliffParser::getSupportedFileExtensions();


### PR DESCRIPTION
## Summary

- `XliffParser::getContentByKey()` performed a linear scan over all translation units on every call. Since several validators call it in a loop over all keys, lookups were O(n²) per file — dominating runtime on large XLIFF files.
- Content is now resolved through a map of unit id to content that is built once (lazily) and memoized, making lookups O(1). The previous fallback and empty-value semantics are preserved (first unit yielding non-empty content wins; empty entries resolve to `null`).

## Changes

- `src/Parser/XliffParser.php` — build and memoize an id→content map; `getContentByKey()` becomes a hash lookup
- `tests/src/Parser/XliffParserTest.php` — cover the empty-source/target case and repeated (memoized) lookups

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved translation lookup reliability when source and target values are empty.
  * Empty translation entries now correctly return no content, while populated entries continue to return the expected translation.
  * Repeated lookups now provide consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->