### PR TITLE
perf: cache prepared XLIFF schema source per version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
 	],
 	"require": {
 		"php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+		"ext-dom": "*",
 		"ext-libxml": "*",
 		"ext-mbstring": "*",
 		"ext-simplexml": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b72dd8ab852c54f894044f9081ac8731",
+    "content-hash": "13d8a9e421bb2b94312211d8afd2b9c1",
     "packages": [
         {
             "name": "justinrainbow/json-schema",
@@ -6999,6 +6999,7 @@
     "prefer-lowest": false,
     "platform": {
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+        "ext-dom": "*",
         "ext-libxml": "*",
         "ext-mbstring": "*",
         "ext-simplexml": "*",

--- a/src/Validator/XliffSchemaValidator.php
+++ b/src/Validator/XliffSchemaValidator.php
@@ -13,14 +13,18 @@ declare(strict_types=1);
 
 namespace MoveElevator\ComposerTranslationValidator\Validator;
 
+use DOMDocument;
 use Exception;
 use MoveElevator\ComposerTranslationValidator\Enum\LocaleMatch;
 use MoveElevator\ComposerTranslationValidator\Parser\{ParserInterface, XliffParser};
 use MoveElevator\ComposerTranslationValidator\Result\Issue;
 use MoveElevator\ComposerTranslationValidator\Utility\LocaleUtility;
+use ReflectionMethod;
 use Symfony\Component\Config\Util\XmlUtils;
 use Symfony\Component\Translation\Util\XliffUtils;
+use Throwable;
 
+use function is_string;
 use function sprintf;
 
 /**
@@ -31,6 +35,15 @@ use function sprintf;
  */
 class XliffSchemaValidator extends AbstractValidator implements ValidatorInterface
 {
+    /**
+     * Prepared XLIFF schema source per version, cached for the whole process.
+     *
+     * @var array<string, string>
+     */
+    private static array $schemaSourceCache = [];
+
+    private static ?ReflectionMethod $getSchemaMethod = null;
+
     public function processFile(ParserInterface $file): array
     {
         /*
@@ -63,7 +76,7 @@ class XliffSchemaValidator extends AbstractValidator implements ValidatorInterfa
         // Schema validation — may throw for unsupported XLIFF versions (e.g. 2.x)
         $errors = [];
         try {
-            $errors = XliffUtils::validateSchema($dom);
+            $errors = $this->validateSchema($dom);
         } catch (Exception $e) {
             if (str_contains($e->getMessage(), 'No support implemented for loading XLIFF version')) {
                 $this->logger?->notice(sprintf('Skipping %s: %s', $this->getShortName(), $e->getMessage()));
@@ -153,5 +166,85 @@ class XliffSchemaValidator extends AbstractValidator implements ValidatorInterfa
     public function supportsParser(): array
     {
         return [XliffParser::class];
+    }
+
+    /**
+     * Validates a document against the XLIFF schema.
+     *
+     * Symfony's XliffUtils::validateSchema() re-reads and re-prepares the ~105 KB
+     * XSD on every call. We cache the prepared schema source per version so this
+     * work happens once per process; only the (uncacheable) libxml compilation
+     * runs per file. Any failure to obtain the cached schema falls back to the
+     * unmodified Symfony behaviour, preserving correctness.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function validateSchema(DOMDocument $dom): array
+    {
+        $schemaSource = $this->getCachedSchemaSource($dom);
+        if (null === $schemaSource) {
+            return XliffUtils::validateSchema($dom);
+        }
+
+        $internalErrors = libxml_use_internal_errors(true);
+
+        if (!@$dom->schemaValidateSource($schemaSource)) {
+            $errors = [];
+            foreach (libxml_get_errors() as $error) {
+                $errors[] = [
+                    'level' => \LIBXML_ERR_WARNING === $error->level ? 'WARNING' : 'ERROR',
+                    'code' => $error->code,
+                    'message' => trim($error->message),
+                    'file' => $error->file ?: 'n/a',
+                    'line' => $error->line,
+                    'column' => $error->column,
+                ];
+            }
+            libxml_clear_errors();
+            libxml_use_internal_errors($internalErrors);
+
+            return $errors;
+        }
+
+        $dom->normalizeDocument();
+        libxml_clear_errors();
+        libxml_use_internal_errors($internalErrors);
+
+        return [];
+    }
+
+    /**
+     * Returns the prepared schema source for the document's XLIFF version, or
+     * null when it cannot be resolved (e.g. unsupported version or a change in
+     * Symfony internals), in which case the caller falls back to Symfony.
+     */
+    private function getCachedSchemaSource(DOMDocument $dom): ?string
+    {
+        try {
+            $version = XliffUtils::getVersionNumber($dom);
+            // @codeCoverageIgnoreStart
+        } catch (Throwable) {
+            return null;
+        }
+        // @codeCoverageIgnoreEnd
+
+        if (isset(self::$schemaSourceCache[$version])) {
+            return self::$schemaSourceCache[$version];
+        }
+
+        try {
+            self::$getSchemaMethod ??= new ReflectionMethod(XliffUtils::class, 'getSchema');
+            $schemaSource = self::$getSchemaMethod->invoke(null, $version);
+        } catch (Throwable) {
+            return null;
+        }
+
+        // @codeCoverageIgnoreStart
+        if (!is_string($schemaSource)) {
+            return null;
+        }
+        // @codeCoverageIgnoreEnd
+
+        return self::$schemaSourceCache[$version] = $schemaSource;
     }
 }

--- a/tests/src/Validator/XliffSchemaValidatorTest.php
+++ b/tests/src/Validator/XliffSchemaValidatorTest.php
@@ -73,6 +73,64 @@ XML;
         $this->assertSame([], $result);
     }
 
+    public function testProcessFileReportsSchemaErrorsViaCachedSchema(): void
+    {
+        // Well-formed XML but schema-invalid: <trans-unit> requires an "id".
+        $invalidXliff = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" original="test.xlf" datatype="plaintext">
+        <body>
+            <trans-unit>
+                <source>Hello</source>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>
+XML;
+
+        $tempFile = tempnam(sys_get_temp_dir(), 'xliff_test_');
+        file_put_contents($tempFile, $invalidXliff);
+
+        $parser = $this->createStub(XliffParser::class);
+        $parser->method('getFilePath')->willReturn($tempFile);
+        $parser->method('getFileName')->willReturn('test.xlf');
+
+        $result = $this->validator->processFile($parser);
+
+        unlink($tempFile);
+
+        $this->assertNotEmpty($result);
+        $this->assertSame('ERROR', $result[0]['level']);
+    }
+
+    public function testProcessFileReusesCachedSchemaAcrossFiles(): void
+    {
+        $validXliff = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" original="reuse.xlf" datatype="plaintext">
+        <body>
+            <trans-unit id="a"><source>Hello</source></trans-unit>
+        </body>
+    </file>
+</xliff>
+XML;
+
+        $tempFile = tempnam(sys_get_temp_dir(), 'xliff_test_');
+        file_put_contents($tempFile, $validXliff);
+
+        $parser = $this->createStub(XliffParser::class);
+        $parser->method('getFilePath')->willReturn($tempFile);
+        $parser->method('getFileName')->willReturn('reuse.xlf');
+
+        // Two runs exercise the per-version schema-source cache.
+        $this->assertSame([], $this->validator->processFile($parser));
+        $this->assertSame([], $this->validator->processFile($parser));
+
+        unlink($tempFile);
+    }
+
     public function testProcessFileWithNonExistentFile(): void
     {
         $parser = $this->createStub(XliffParser::class);


### PR DESCRIPTION
## Summary

- `XliffSchemaValidator` delegated to `XliffUtils::validateSchema()`, which re-reads and re-prepares the ~105 KB XLIFF XSD on every file. On projects with many XLIFF files this repeated I/O and string processing was significant.
- The prepared schema source is now cached per XLIFF version for the whole process; only libxml's (uncacheable) compilation runs per file. Resolving the cached schema is wrapped in a full fallback to the unmodified Symfony behaviour, so correctness is preserved even if Symfony internals change.

## Changes

- `src/Validator/XliffSchemaValidator.php` — cache the per-version schema source and validate with `schemaValidateSource()`, falling back to `XliffUtils::validateSchema()` on any resolution failure
- `tests/src/Validator/XliffSchemaValidatorTest.php` — cover schema-error reporting via the cached path and cross-file cache reuse

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved XLIFF validation so schema issues are detected more reliably and reported as file errors.
  * Validation now reuses prepared schema data when processing multiple XLIFF files, which can make repeated checks faster and more consistent.

* **Tests**
  * Added coverage for schema error reporting and repeated validation of the same XLIFF version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->