### PR TITLE
perf: memoize extractKeys() results in parsers

### DIFF
--- a/src/Parser/JsonParser.php
+++ b/src/Parser/JsonParser.php
@@ -32,6 +32,9 @@ class JsonParser extends AbstractParser implements ParserInterface
     /** @var array<string, mixed> */
     private array $json = [];
 
+    /** @var array<int, string>|null Memoized result of extractKeys(). */
+    private ?array $extractedKeys = null;
+
     public function __construct(string $filePath)
     {
         parent::__construct($filePath);
@@ -60,6 +63,10 @@ class JsonParser extends AbstractParser implements ParserInterface
      */
     public function extractKeys(): ?array
     {
+        if (null !== $this->extractedKeys) {
+            return $this->extractedKeys;
+        }
+
         $extract = static function (
             array $data,
             string $prefix = '',
@@ -82,7 +89,7 @@ class JsonParser extends AbstractParser implements ParserInterface
             return $keys;
         };
 
-        return $extract($this->json);
+        return $this->extractedKeys = $extract($this->json);
     }
 
     public function getContentByKey(string $key): ?string

--- a/src/Parser/PhpParser.php
+++ b/src/Parser/PhpParser.php
@@ -33,6 +33,9 @@ class PhpParser extends AbstractParser implements ParserInterface
     /** @var array<string, mixed> */
     private array $translations = [];
 
+    /** @var array<int, string>|null Memoized result of extractKeys(). */
+    private ?array $extractedKeys = null;
+
     public function __construct(string $filePath)
     {
         parent::__construct($filePath);
@@ -49,8 +52,12 @@ class PhpParser extends AbstractParser implements ParserInterface
      */
     public function extractKeys(): ?array
     {
+        if (null !== $this->extractedKeys) {
+            return $this->extractedKeys;
+        }
+
         if (empty($this->translations)) {
-            return [];
+            return $this->extractedKeys = [];
         }
 
         $extract = static function (
@@ -75,7 +82,7 @@ class PhpParser extends AbstractParser implements ParserInterface
             return $keys;
         };
 
-        return $extract($this->translations);
+        return $this->extractedKeys = $extract($this->translations);
     }
 
     public function getContentByKey(string $key): ?string

--- a/src/Parser/XliffParser.php
+++ b/src/Parser/XliffParser.php
@@ -30,6 +30,9 @@ class XliffParser extends AbstractParser implements ParserInterface
     private readonly SimpleXMLElement|bool $xml;
     private readonly bool $isVersion2;
 
+    /** @var array<int, string>|null Memoized result of extractKeys(). */
+    private ?array $extractedKeys = null;
+
     /**
      * @param string $filePath Path to the XLIFF file
      *
@@ -63,9 +66,13 @@ class XliffParser extends AbstractParser implements ParserInterface
      */
     public function extractKeys(): ?array
     {
+        if (null !== $this->extractedKeys) {
+            return $this->extractedKeys;
+        }
+
         $units = $this->getTranslationUnits();
         if (null === $units) {
-            return [];
+            return $this->extractedKeys = [];
         }
 
         $keys = [];
@@ -73,7 +80,7 @@ class XliffParser extends AbstractParser implements ParserInterface
             $keys[] = (string) $unit['id'];
         }
 
-        return $keys;
+        return $this->extractedKeys = $keys;
     }
 
     public function getContentByKey(string $key): ?string

--- a/src/Parser/YamlParser.php
+++ b/src/Parser/YamlParser.php
@@ -33,6 +33,9 @@ class YamlParser extends AbstractParser implements ParserInterface
     /** @var array<string, mixed> */
     private array $yaml = [];
 
+    /** @var array<int, string>|null Memoized result of extractKeys(). */
+    private ?array $extractedKeys = null;
+
     public function __construct(string $filePath)
     {
         parent::__construct($filePath);
@@ -49,6 +52,10 @@ class YamlParser extends AbstractParser implements ParserInterface
      */
     public function extractKeys(): ?array
     {
+        if (null !== $this->extractedKeys) {
+            return $this->extractedKeys;
+        }
+
         $extract = static function (
             array $data,
             string $prefix = '',
@@ -71,7 +78,7 @@ class YamlParser extends AbstractParser implements ParserInterface
             return $keys;
         };
 
-        return $extract($this->yaml);
+        return $this->extractedKeys = $extract($this->yaml);
     }
 
     public function getContentByKey(string $key): ?string

--- a/tests/src/Parser/JsonParserTest.php
+++ b/tests/src/Parser/JsonParserTest.php
@@ -107,6 +107,17 @@ final class JsonParserTest extends TestCase
         $this->assertSame(['parent.child1', 'parent.child2'], $nestedKeys);
     }
 
+    public function testExtractKeysIsMemoized(): void
+    {
+        $parser = new JsonParser($this->validJsonFile);
+
+        $first = $parser->extractKeys();
+        $second = $parser->extractKeys();
+
+        $this->assertSame(['key1', 'key2'], $first);
+        $this->assertSame($first, $second);
+    }
+
     public function testGetContentByKey(): void
     {
         $parser = new JsonParser($this->validJsonFile);

--- a/tests/src/Parser/PhpParserTest.php
+++ b/tests/src/Parser/PhpParserTest.php
@@ -105,6 +105,17 @@ final class PhpParserTest extends TestCase
         }
     }
 
+    public function testExtractKeysIsMemoized(): void
+    {
+        $filePath = __DIR__.'/../Fixtures/translations/php/success/messages.en.php';
+        $parser = new PhpParser($filePath);
+
+        $first = $parser->extractKeys();
+        $second = $parser->extractKeys();
+
+        $this->assertSame($first, $second);
+    }
+
     public function testGetContentByKeyWithValidKeys(): void
     {
         $filePath = __DIR__.'/../Fixtures/translations/php/success/messages.en.php';

--- a/tests/src/Parser/XliffParserTest.php
+++ b/tests/src/Parser/XliffParserTest.php
@@ -205,6 +205,17 @@ EOT;
         $this->assertSame(['key1', 'key2', 'key3'], $keys);
     }
 
+    public function testExtractKeysIsMemoized(): void
+    {
+        $parser = new XliffParser($this->validXliffFile);
+
+        $first = $parser->extractKeys();
+        $second = $parser->extractKeys();
+
+        $this->assertSame(['key1', 'key2', 'key3'], $first);
+        $this->assertSame($first, $second);
+    }
+
     public function testGetContentByKeySource(): void
     {
         $parser = new XliffParser($this->validXliffFile);

--- a/tests/src/Parser/YamlParserTest.php
+++ b/tests/src/Parser/YamlParserTest.php
@@ -92,6 +92,17 @@ EOT
         $this->assertSame(['parent.child1', 'parent.child2'], $nestedKeys);
     }
 
+    public function testExtractKeysIsMemoized(): void
+    {
+        $parser = new YamlParser($this->validYamlFile);
+
+        $first = $parser->extractKeys();
+        $second = $parser->extractKeys();
+
+        $this->assertSame(['key1', 'key2'], $first);
+        $this->assertSame($first, $second);
+    }
+
     public function testGetContentByKey(): void
     {
         $parser = new YamlParser($this->validYamlFile);


### PR DESCRIPTION
## Summary

- Every validator (and the statistics step) calls `extractKeys()` on each parsed file, recomputing the key list 11–12 times per file — for XLIFF via SimpleXML iteration, for YAML/JSON/PHP via a recursive walk of the full nested array.
- Each parser now memoizes its `extractKeys()` result, so the work runs once per file.

## Changes

- `src/Parser/XliffParser.php`, `YamlParser.php`, `JsonParser.php`, `PhpParser.php` — memoize the extracted key list
- `tests/src/Parser/*ParserTest.php` — assert repeated `extractKeys()` calls return the same (memoized) result

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved translation key extraction by reusing previously computed results on repeated calls.
  * Empty translation sources are handled efficiently without repeated processing.

* **Tests**
  * Added coverage verifying consistent results across repeated key extraction for JSON, PHP, XLIFF, and YAML formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->