### PR TITLE
perf: evict parser cache per file set to bound memory

### DIFF
--- a/src/Parser/ParserCache.php
+++ b/src/Parser/ParserCache.php
@@ -48,6 +48,11 @@ class ParserCache
         $this->cache = [];
     }
 
+    public function count(): int
+    {
+        return count($this->cache);
+    }
+
     /** @return array<string, mixed> */
     public function getCacheStats(): array
     {

--- a/src/Result/ValidationRun.php
+++ b/src/Result/ValidationRun.php
@@ -47,6 +47,8 @@ class ValidationRun
         $validatorFileSetPairs = [];
         $overallResult = ResultType::SUCCESS;
         $filesChecked = 0;
+        $keysChecked = 0;
+        $parsersCached = 0;
 
         foreach ($fileSets as $fileSet) {
             $filesChecked += count($fileSet->getFiles());
@@ -76,15 +78,15 @@ class ValidationRun
                     ];
                 }
             }
+
+            // Count keys while this FileSet's parsers are still cached, then evict
+            // them so the cache does not grow with the number of processed FileSets.
+            $keysChecked += $this->countKeysChecked($fileSet);
+            $parsersCached += $this->parserCache->count();
+            $this->parserCache->clear();
         }
 
-        $keysChecked = $this->countKeysChecked($fileSets);
-
         $validatorsRun = count($validatorClasses);
-
-        // Get cache statistics before clearing cache
-        $cacheStats = $this->parserCache->getCacheStats();
-        $parsersCached = $cacheStats['cached_parsers'];
 
         $executionTime = microtime(true) - $startTime;
         $statistics = new ValidationStatistics(
@@ -95,10 +97,7 @@ class ValidationRun
             $parsersCached,
         );
 
-        $validationResult = new ValidationResult($validatorInstances, $overallResult, $validatorFileSetPairs, $statistics);
-        $this->parserCache->clear();
-
-        return $validationResult;
+        return new ValidationResult($validatorInstances, $overallResult, $validatorFileSetPairs, $statistics);
     }
 
     /**
@@ -121,31 +120,25 @@ class ValidationRun
         return $fileSets;
     }
 
-    /**
-     * @param array<FileSet> $fileSets
-     */
-    private function countKeysChecked(array $fileSets): int
+    private function countKeysChecked(FileSet $fileSet): int
     {
         $keysChecked = 0;
+        $parserClass = $fileSet->getParser();
 
-        foreach ($fileSets as $fileSet) {
-            $parserClass = $fileSet->getParser();
-
-            foreach ($fileSet->getFiles() as $file) {
-                try {
-                    $parser = $this->parserCache->get($file, $parserClass);
-                    // @codeCoverageIgnoreStart
-                    if (false === $parser) {
-                        continue;
-                    }
-                    // @codeCoverageIgnoreEnd
-                    $keys = $parser->extractKeys();
-                    if (is_array($keys)) {
-                        $keysChecked += count($keys);
-                    }
-                } catch (Throwable) {
-                    // Skip files that can't be parsed
+        foreach ($fileSet->getFiles() as $file) {
+            try {
+                $parser = $this->parserCache->get($file, $parserClass);
+                // @codeCoverageIgnoreStart
+                if (false === $parser) {
+                    continue;
                 }
+                // @codeCoverageIgnoreEnd
+                $keys = $parser->extractKeys();
+                if (is_array($keys)) {
+                    $keysChecked += count($keys);
+                }
+            } catch (Throwable) {
+                // Skip files that can't be parsed
             }
         }
 


### PR DESCRIPTION
## Summary

- The shared `ParserCache` kept every parsed file (full document tree) in memory until the end of the run, so peak memory grew with the total number of files even though processing is strictly per file set.
- Keys are now counted for each file set while its parsers are still warm, after which the cache is evicted before the next file set. Peak memory is bounded to a single file set's files. The `parsers_cached` statistic is preserved by accumulating per-file-set cache sizes.

## Changes

- `src/Parser/ParserCache.php` — add `count()`
- `src/Result/ValidationRun.php` — count keys inline per file set, accumulate the cached-parser count, and clear the cache after each file set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation processing to track parser cache and key-check statistics accurately for each file set.
  * Prevented parser cache growth across multiple file sets, helping maintain more consistent memory usage during larger validation runs.
  * Preserved existing parser retrieval, clearing, and cache statistics behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->