### PR TITLE
perf: scan each directory once and bucket files by parser

### DIFF
--- a/src/FileDetector/Collector.php
+++ b/src/FileDetector/Collector.php
@@ -55,8 +55,12 @@ class Collector
                 continue;
             }
 
+            // Scan the directory once and bucket files by their parser, instead
+            // of scanning it separately for every parser class.
+            $filesByParser = $this->scanFilesByParser($path, $recursive);
+
             foreach (ParserRegistry::getAvailableParsers() as $parserClass) {
-                $files = $this->findFiles($path, $parserClass::getSupportedFileExtensions(), $recursive);
+                $files = $filesByParser[$parserClass] ?? [];
                 if (empty($files)) {
                     $this->logger?->debug('No files found for parser class "'.$parserClass.'" in path "'.$path.'".');
                     continue;
@@ -99,6 +103,45 @@ class Collector
         }
 
         return $allFiles;
+    }
+
+    /**
+     * Scans a path once and groups the found files by their parser class.
+     *
+     * @return array<class-string, string[]>
+     */
+    private function scanFilesByParser(string $path, bool $recursive): array
+    {
+        $extensionMap = self::extensionToParserMap();
+        $files = $this->findFiles($path, array_keys($extensionMap), $recursive);
+
+        $filesByParser = [];
+        foreach ($files as $file) {
+            $extension = pathinfo((string) $file, \PATHINFO_EXTENSION);
+            if (isset($extensionMap[$extension])) {
+                $filesByParser[$extensionMap[$extension]][] = $file;
+            }
+        }
+
+        return $filesByParser;
+    }
+
+    /**
+     * Maps each supported file extension to the parser class handling it.
+     * The first parser declaring an extension wins, matching parser resolution.
+     *
+     * @return array<string, class-string>
+     */
+    private static function extensionToParserMap(): array
+    {
+        $map = [];
+        foreach (ParserRegistry::getAvailableParsers() as $parserClass) {
+            foreach ($parserClass::getSupportedFileExtensions() as $extension) {
+                $map[$extension] ??= $parserClass;
+            }
+        }
+
+        return $map;
     }
 
     /**


### PR DESCRIPTION
## Summary

- `collectFiles()` scanned every path once per parser class (4 times), so a recursive scan of a large tree walked it four times.
- Each path is now scanned once and the found files are bucketed by their parser via an extension→parser map. Per-parser processing, exclude filtering, detector grouping and the existing debug logging are unchanged.

## Changes

- `src/FileDetector/Collector.php` — add `scanFilesByParser()` and `extensionToParserMap()`; drive the per-parser loop from a single scan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved file discovery speed by scanning supported files in a directory once instead of repeating the scan for each parser.
  * Maintained existing exclusion-pattern filtering during file collection.

* **Behavior Changes**
  * Files with extensions supported by multiple parsers are now assigned to the first applicable parser, rather than being processed by every matching parser.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->