### PR TITLE
perf: reuse parser-read file content in encoding validation

### DIFF
--- a/src/Parser/AbstractParser.php
+++ b/src/Parser/AbstractParser.php
@@ -30,6 +30,8 @@ abstract class AbstractParser
 {
     protected readonly string $fileName;
 
+    protected ?string $rawContent = null;
+
     public function __construct(protected readonly string $filePath)
     {
         if (!file_exists($filePath)) {
@@ -64,6 +66,24 @@ abstract class AbstractParser
     public function getFilePath(): string
     {
         return $this->filePath;
+    }
+
+    /**
+     * Returns the raw file content, reading it at most once.
+     *
+     * Parsers that already read the file while parsing populate this, so
+     * consumers (e.g. the encoding validator) can reuse it instead of reading
+     * the file from disk again. Returns null if the file cannot be read.
+     */
+    public function getRawContent(): ?string
+    {
+        if (null !== $this->rawContent) {
+            return $this->rawContent;
+        }
+
+        $content = file_get_contents($this->filePath);
+
+        return false === $content ? null : ($this->rawContent = $content);
     }
 
     /**

--- a/src/Parser/JsonParser.php
+++ b/src/Parser/JsonParser.php
@@ -44,6 +44,8 @@ class JsonParser extends AbstractParser implements ParserInterface
             }
             // @codeCoverageIgnoreEnd
 
+            $this->rawContent = $content;
+
             $decoded = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
             if (!is_array($decoded) || array_is_list($decoded)) {
                 throw new RuntimeException("JSON file does not contain an object: {$filePath}");

--- a/src/Parser/XliffParser.php
+++ b/src/Parser/XliffParser.php
@@ -47,6 +47,8 @@ class XliffParser extends AbstractParser implements ParserInterface
         }
         // @codeCoverageIgnoreEnd
 
+        $this->rawContent = $xmlContent;
+
         libxml_use_internal_errors(true);
         $this->xml = simplexml_load_string($xmlContent);
 

--- a/src/Validator/EncodingValidator.php
+++ b/src/Validator/EncodingValidator.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace MoveElevator\ComposerTranslationValidator\Validator;
 
-use MoveElevator\ComposerTranslationValidator\Parser\{JsonParser, ParserInterface, PhpParser, XliffParser, YamlParser};
+use MoveElevator\ComposerTranslationValidator\Parser\{AbstractParser, JsonParser, ParserInterface, PhpParser, XliffParser, YamlParser};
 use MoveElevator\ComposerTranslationValidator\Result\Issue;
 use Normalizer;
 
@@ -44,10 +44,17 @@ class EncodingValidator extends AbstractValidator implements ValidatorInterface
             return [];
         }
 
-        // Read raw file content
-        $content = file_get_contents($filePath);
+        // Reuse the content already read by the parser when possible, otherwise
+        // read it from disk.
+        if ($file instanceof AbstractParser) {
+            $content = $file->getRawContent();
+        } else {
+            $raw = file_get_contents($filePath);
+            $content = false === $raw ? null : $raw;
+        }
+
         // @codeCoverageIgnoreStart
-        if (false === $content) {
+        if (null === $content) {
             $this->logger?->error(
                 'Could not read file content: '.$file->getFileName(),
             );

--- a/tests/src/Parser/AbstractParserTest.php
+++ b/tests/src/Parser/AbstractParserTest.php
@@ -148,4 +148,22 @@ final class AbstractParserTest extends TestCase
 
         unlink($testFile);
     }
+
+    public function testGetRawContentReadsFileLazily(): void
+    {
+        $parser = new TestParser($this->tempFile);
+
+        $this->assertSame('test content', $parser->getRawContent());
+    }
+
+    public function testGetRawContentCachesResult(): void
+    {
+        $parser = new TestParser($this->tempFile);
+
+        $this->assertSame('test content', $parser->getRawContent());
+
+        file_put_contents($this->tempFile, 'changed content');
+
+        $this->assertSame('test content', $parser->getRawContent());
+    }
 }

--- a/tests/src/Parser/XliffParserTest.php
+++ b/tests/src/Parser/XliffParserTest.php
@@ -225,6 +225,14 @@ EOT;
         $this->assertNull($parser->getContentByKey('nonexistent_key'));
     }
 
+    public function testGetRawContentReturnsFileContentAndIsMemoized(): void
+    {
+        $parser = new XliffParser($this->validXliffFile);
+
+        $this->assertSame($this->validXliffContent, $parser->getRawContent());
+        $this->assertSame($parser->getRawContent(), $parser->getRawContent());
+    }
+
     public function testGetSupportedFileExtensions(): void
     {
         $extensions = XliffParser::getSupportedFileExtensions();

--- a/tests/src/Validator/EncodingValidatorTest.php
+++ b/tests/src/Validator/EncodingValidatorTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace MoveElevator\ComposerTranslationValidator\Tests\Validator;
 
-use MoveElevator\ComposerTranslationValidator\Parser\{JsonParser, PhpParser, XliffParser, YamlParser};
+use MoveElevator\ComposerTranslationValidator\Parser\{JsonParser, ParserInterface, PhpParser, XliffParser, YamlParser};
 use MoveElevator\ComposerTranslationValidator\Result\Issue;
 use MoveElevator\ComposerTranslationValidator\Validator\{EncodingValidator, ResultType};
 use Normalizer;
@@ -159,6 +159,22 @@ final class EncodingValidatorTest extends TestCase
         $this->assertStringContainsString('non-NFC normalized', $issues['unicode_normalization']);
     }
 
+    public function testReadsFromDiskForNonAbstractParser(): void
+    {
+        $filePath = $this->testFilesPath.'/plain-interface.yaml';
+        file_put_contents($filePath, 'key: value');
+
+        // A parser that implements the interface but does not extend
+        // AbstractParser exercises the direct file-read fallback.
+        $parser = $this->createStub(ParserInterface::class);
+        $parser->method('getFilePath')->willReturn($filePath);
+        $parser->method('getFileName')->willReturn('plain-interface.yaml');
+
+        $issues = $this->validator->processFile($parser);
+
+        $this->assertEmpty($issues);
+    }
+
     public function testJsonFilesAreSupported(): void
     {
         $filePath = $this->testFilesPath.'/valid.json';
@@ -174,11 +190,13 @@ final class EncodingValidatorTest extends TestCase
     public function testJsonWithBomIsDetected(): void
     {
         $filePath = $this->testFilesPath.'/valid-json-with-bom.json';
-        file_put_contents($filePath, "\xEF\xBB\xBF{\"key\": \"value\"}"); // Valid JSON with BOM
+        $content = "\xEF\xBB\xBF{\"key\": \"value\"}"; // Valid JSON with BOM
+        file_put_contents($filePath, $content);
 
         // Mock parser to avoid BOM parsing issues
         $mockParser = $this->createStub(JsonParser::class);
         $mockParser->method('getFilePath')->willReturn($filePath);
+        $mockParser->method('getRawContent')->willReturn($content);
 
         $issues = $this->validator->processFile($mockParser);
 
@@ -207,7 +225,7 @@ final class EncodingValidatorTest extends TestCase
             ->with($this->stringContains('Could not read file content:'));
 
         $validator = new class($logger) extends EncodingValidator {
-            public function processFile(\MoveElevator\ComposerTranslationValidator\Parser\ParserInterface $file): array
+            public function processFile(ParserInterface $file): array
             {
                 // Simulate file_get_contents returning false
                 $content = @file_get_contents($file->getFilePath()); // Suppress warning with @
@@ -309,7 +327,7 @@ final class EncodingValidatorTest extends TestCase
         file_put_contents($filePath, ''); // Completely empty file
 
         // Create a mock parser that can handle empty files
-        $mockParser = $this->createStub(\MoveElevator\ComposerTranslationValidator\Parser\ParserInterface::class);
+        $mockParser = $this->createStub(ParserInterface::class);
         $mockParser->method('getFilePath')->willReturn($filePath);
         $mockParser->method('getFileName')->willReturn('just-empty-content.txt');
 
@@ -325,7 +343,7 @@ final class EncodingValidatorTest extends TestCase
         file_put_contents($filePath, 'test content');
 
         // Create mock parser
-        $mockParser = $this->createStub(\MoveElevator\ComposerTranslationValidator\Parser\ParserInterface::class);
+        $mockParser = $this->createStub(ParserInterface::class);
         $mockParser->method('getFilePath')->willReturn($filePath);
         $mockParser->method('getFileName')->willReturn('temp-file.yaml');
 


### PR DESCRIPTION
## Summary

- The encoding validator read each file from disk again even though the parser had already read it while parsing.
- Parsers now expose the raw file content via `AbstractParser::getRawContent()`, read at most once. XLIFF and JSON parsers reuse the content they already read in their constructor; the encoding validator consumes it instead of reading the file a second time.

## Changes

- `src/Parser/AbstractParser.php` — add lazily-read, memoized `getRawContent()`
- `src/Parser/XliffParser.php`, `JsonParser.php` — populate the raw content from the constructor read
- `src/Validator/EncodingValidator.php` — reuse `getRawContent()` when the file is an `AbstractParser` (falls back to a direct read otherwise)
- tests — cover `getRawContent()` and adjust the BOM stub

Note: XLIFF schema validation still performs its own read plus a DOM parse, which is structurally required for schema validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added access to the original, unmodified file content through parsers.
  * Reuses loaded file content during encoding validation for more efficient processing.
  * Maintains disk-based reading for compatible custom parsers.

* **Bug Fixes**
  * Preserved existing handling for unreadable files and encoding issues.

* **Tests**
  * Added coverage for raw content retrieval, reuse, and parser compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->