### PR TITLE
perf: return bool from validator validate() instead of building issue arrays

### DIFF
--- a/src/Result/ValidationRun.php
+++ b/src/Result/ValidationRun.php
@@ -66,8 +66,7 @@ class ValidationRun
 
                 /** @var class-string<\MoveElevator\ComposerTranslationValidator\Parser\ParserInterface> $parserClass */
                 $parserClass = $fileSet->getParser();
-                $result = $validatorInstance->validate($fileSet->getFiles(), $parserClass);
-                if (!empty($result)) {
+                if ($validatorInstance->validate($fileSet->getFiles(), $parserClass)) {
                     $overallResult = $overallResult->max($validatorInstance->resultTypeOnValidationFailure());
                     $validatorInstances[] = $validatorInstance;
                     $validatorFileSetPairs[] = [

--- a/src/Validator/AbstractValidator.php
+++ b/src/Validator/AbstractValidator.php
@@ -49,10 +49,8 @@ abstract class AbstractValidator
     /**
      * @param string[]                           $files
      * @param class-string<ParserInterface>|null $parserClass
-     *
-     * @return array<string, array<mixed>>
      */
-    public function validate(array $files, ?string $parserClass): array
+    public function validate(array $files, ?string $parserClass): bool
     {
         // Reset state for fresh validation run
         $this->resetState();
@@ -137,7 +135,7 @@ abstract class AbstractValidator
 
         $this->postProcess();
 
-        return array_map(static fn ($issue) => $issue->toArray(), $this->issues);
+        return $this->hasIssues();
     }
 
     /**

--- a/src/Validator/ValidatorInterface.php
+++ b/src/Validator/ValidatorInterface.php
@@ -32,12 +32,13 @@ interface ValidatorInterface
     public function processFile(ParserInterface $file): array;
 
     /**
+     * Runs the validator over the given files and returns whether any issue was
+     * found. The issues themselves are available via getIssues().
+     *
      * @param array<string>                 $files
      * @param class-string<ParserInterface> $parserClass
-     *
-     * @return array<string, mixed>
      */
-    public function validate(array $files, string $parserClass): array;
+    public function validate(array $files, string $parserClass): bool;
 
     /**
      * @return class-string<ParserInterface>[]

--- a/src/Validator/ValidatorInterface.php
+++ b/src/Validator/ValidatorInterface.php
@@ -35,10 +35,10 @@ interface ValidatorInterface
      * Runs the validator over the given files and returns whether any issue was
      * found. The issues themselves are available via getIssues().
      *
-     * @param array<string>                 $files
-     * @param class-string<ParserInterface> $parserClass
+     * @param array<string>                      $files
+     * @param class-string<ParserInterface>|null $parserClass
      */
-    public function validate(array $files, string $parserClass): bool;
+    public function validate(array $files, ?string $parserClass): bool;
 
     /**
      * @return class-string<ParserInterface>[]

--- a/tests/src/Result/ValidationResultJsonRendererTest.php
+++ b/tests/src/Result/ValidationResultJsonRendererTest.php
@@ -444,7 +444,7 @@ final class ValidationResultJsonRendererTest extends TestCase
         $validator->method('getShortName')->willReturn('MockValidator');
         $validator->method('supportsParser')->willReturn(['TestParser']);
         $validator->method('processFile')->willReturn([]);
-        $validator->method('validate')->willReturn([]);
+        $validator->method('validate')->willReturn(true);
         $validator->method('addIssue');
 
         return $validator;

--- a/tests/src/Result/ValidationRunTest.php
+++ b/tests/src/Result/ValidationRunTest.php
@@ -305,12 +305,9 @@ class MockValidatorWithoutIssues implements ValidatorInterface
         unset($logger);
     }
 
-    /**
-     * @return array<string, mixed>
-     */
-    public function validate(array $files, string $parserClass): array
+    public function validate(array $files, string $parserClass): bool
     {
-        return [];
+        return false;
     }
 
     /**
@@ -380,12 +377,9 @@ class MockValidatorWithIssues implements ValidatorInterface
         unset($logger);
     }
 
-    /**
-     * @return array<string, mixed>
-     */
-    public function validate(array $files, string $parserClass): array
+    public function validate(array $files, string $parserClass): bool
     {
-        return ['mock_issue' => 'test'];
+        return true;
     }
 
     /**

--- a/tests/src/Result/ValidationRunTest.php
+++ b/tests/src/Result/ValidationRunTest.php
@@ -305,7 +305,7 @@ class MockValidatorWithoutIssues implements ValidatorInterface
         unset($logger);
     }
 
-    public function validate(array $files, string $parserClass): bool
+    public function validate(array $files, ?string $parserClass): bool
     {
         return false;
     }
@@ -377,7 +377,7 @@ class MockValidatorWithIssues implements ValidatorInterface
         unset($logger);
     }
 
-    public function validate(array $files, string $parserClass): bool
+    public function validate(array $files, ?string $parserClass): bool
     {
         return true;
     }

--- a/tests/src/Validator/AbstractValidatorTest.php
+++ b/tests/src/Validator/AbstractValidatorTest.php
@@ -62,7 +62,7 @@ class ConcreteValidator extends AbstractValidator implements ValidatorInterface
         return [TestParser::class];
     }
 
-    public function validate(array $files, ?string $parserClass): array
+    public function validate(array $files, ?string $parserClass): bool
     {
         return parent::validate($files, $parserClass);
     }
@@ -211,7 +211,8 @@ final class AbstractValidatorTest extends TestCase
 
         $result = $validator->validate($files, $parserClass);
 
-        $this->assertEmpty($result);
+        $this->assertFalse($result);
+        $this->assertFalse($validator->hasIssues());
     }
 
     /**
@@ -226,7 +227,7 @@ final class AbstractValidatorTest extends TestCase
 
         $result = $validator->validate($files, $parserClass);
 
-        /* @phpstan-ignore-next-line method.impossibleType */
+        $this->assertTrue($result);
         $this->assertSame(
             [
                 [
@@ -236,7 +237,7 @@ final class AbstractValidatorTest extends TestCase
                     'type' => ConcreteValidator::class,
                 ],
             ],
-            $result,
+            array_map(static fn ($issue) => $issue->toArray(), $validator->getIssues()),
         );
     }
 
@@ -262,12 +263,13 @@ final class AbstractValidatorTest extends TestCase
 
         $result = $validator->validate($files, $parserClass);
 
+        $this->assertTrue($result);
         $this->assertContains([
             'file' => 'test_file.xlf',
             'issues' => ['postProcessIssue'],
             'parser' => 'TestParser',
             'type' => 'ConcreteValidator',
-        ], $result);
+        ], array_map(static fn ($issue) => $issue->toArray(), $validator->getIssues()));
     }
 
     public function testHasIssuesReturnsFalseWhenNoIssues(): void
@@ -460,7 +462,7 @@ final class AbstractValidatorTest extends TestCase
 
         $result = $validator->validate(['multi.xlf'], TestParser::class);
 
-        /* @phpstan-ignore-next-line method.impossibleType */
+        $this->assertTrue($result);
         $this->assertSame(
             [
                 [
@@ -476,7 +478,7 @@ final class AbstractValidatorTest extends TestCase
                     'type' => 'MultiIssueValidator',
                 ],
             ],
-            $result,
+            array_map(static fn ($issue) => $issue->toArray(), $validator->getIssues()),
         );
     }
 


### PR DESCRIPTION
## Summary

- `AbstractValidator::validate()` built an array of `toArray()`-serialized issues on every call, but the only production consumer checks it for emptiness — the array was a throwaway allocation. Rendering reads issues from the validator instance via `getIssues()`/`distributeIssuesForDisplay()`, not from this return value.
- `validate()` now returns `bool` (whether any issue was found). Issues remain available via `getIssues()`.

## API note

This changes the `ValidatorInterface::validate()` return type from `array` to `bool`. Custom validators implementing the interface would need to adjust their signature. Flagged for review.

## Changes

- `src/Validator/ValidatorInterface.php`, `AbstractValidator.php` — `validate()` returns `bool`
- `src/Result/ValidationRun.php` — use the boolean result directly
- tests — assert on the boolean result plus `getIssues()`, and update validator mocks/doubles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Validation now reports whether issues were found using a simple true/false result.
  * Detailed validation issues remain available through the validator’s issue collection.
  * Validation runs continue to track overall results and associated validator details consistently.

* **Tests**
  * Updated validation and rendering tests to reflect the new result format and issue retrieval behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->