### PR TITLE
perf: memoize segment convention detection

### DIFF
--- a/src/Validator/ConventionDetector.php
+++ b/src/Validator/ConventionDetector.php
@@ -26,6 +26,15 @@ use function in_array;
 final class ConventionDetector
 {
     /**
+     * Cache of matched conventions per segment string. Segments (e.g. "label",
+     * "title") repeat heavily across keys, so caching avoids re-running every
+     * convention regex for the same segment.
+     *
+     * @var array<string, array<string>>
+     */
+    private array $segmentConventionCache = [];
+
+    /**
      * Detect which conventions a key matches.
      *
      * @return array<string>
@@ -84,6 +93,10 @@ final class ConventionDetector
      */
     public function detectSegmentConventions(string $segment): array
     {
+        if (isset($this->segmentConventionCache[$segment])) {
+            return $this->segmentConventionCache[$segment];
+        }
+
         $matchingConventions = [];
 
         foreach (KeyNamingConvention::cases() as $convention) {
@@ -97,7 +110,7 @@ final class ConventionDetector
             $matchingConventions[] = 'unknown';
         }
 
-        return $matchingConventions;
+        return $this->segmentConventionCache[$segment] = $matchingConventions;
     }
 
     /**

--- a/tests/src/Validator/ConventionDetectorTest.php
+++ b/tests/src/Validator/ConventionDetectorTest.php
@@ -33,6 +33,14 @@ final class ConventionDetectorTest extends TestCase
         $this->detector = new ConventionDetector();
     }
 
+    public function testDetectSegmentConventionsIsMemoized(): void
+    {
+        $first = $this->detector->detectSegmentConventions('label');
+        $second = $this->detector->detectSegmentConventions('label');
+
+        $this->assertSame($first, $second);
+    }
+
     /**
      * @param array<string> $expectedContains
      * @param array<string> $expectedNotContains


### PR DESCRIPTION
## Summary

- When no naming convention is configured, `ConventionDetector` runs every convention regex against every key segment. Segments (`label`, `title`, …) repeat heavily across keys, so the same regexes ran many times over identical strings.
- `detectSegmentConventions()` now caches its result per segment string.

## Changes

- `src/Validator/ConventionDetector.php` — memoize per-segment convention detection
- `tests/src/Validator/ConventionDetectorTest.php` — assert repeated detection is consistent (cache hit)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved naming convention analysis by caching repeated segment checks, reducing redundant processing while preserving existing results.

* **Tests**
  * Added coverage to verify consistent results when the same segment is analyzed multiple times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->