### PR TITLE
perf: memoize placeholder extraction per value

### DIFF
--- a/src/Validator/PlaceholderConsistencyValidator.php
+++ b/src/Validator/PlaceholderConsistencyValidator.php
@@ -35,6 +35,15 @@ class PlaceholderConsistencyValidator extends AbstractValidator implements Valid
     /** @var array<string, array<string, array{value: string, placeholders: array<string>}>> */
     protected array $keyData = [];
 
+    /**
+     * Cache of extracted placeholders per value. The same value is processed
+     * during analysis and again while rendering; memoizing avoids re-running
+     * the placeholder regexes for it.
+     *
+     * @var array<string, array<string>>
+     */
+    private array $placeholderCache = [];
+
     public function processFile(ParserInterface $file): array
     {
         $keys = $file->extractKeys();
@@ -194,6 +203,7 @@ class PlaceholderConsistencyValidator extends AbstractValidator implements Valid
     {
         parent::resetState();
         $this->keyData = [];
+        $this->placeholderCache = [];
     }
 
     /**
@@ -209,6 +219,10 @@ class PlaceholderConsistencyValidator extends AbstractValidator implements Valid
      */
     private function extractPlaceholders(string $value): array
     {
+        if (isset($this->placeholderCache[$value])) {
+            return $this->placeholderCache[$value];
+        }
+
         $placeholders = [];
 
         // Symfony style: %parameter%
@@ -246,7 +260,7 @@ class PlaceholderConsistencyValidator extends AbstractValidator implements Valid
             }
         }
 
-        return array_unique($placeholders);
+        return $this->placeholderCache[$value] = array_unique($placeholders);
     }
 
     /**

--- a/tests/src/Validator/PlaceholderConsistencyValidatorTest.php
+++ b/tests/src/Validator/PlaceholderConsistencyValidatorTest.php
@@ -363,6 +363,33 @@ final class PlaceholderConsistencyValidatorTest extends TestCase
         $this->assertStringContainsString('Hallo %username%!', $outputContent);
     }
 
+    public function testRenderDetailedOutputReusesCachedPlaceholders(): void
+    {
+        $logger = $this->createStub(LoggerInterface::class);
+        $validator = new PlaceholderConsistencyValidator($logger);
+
+        // Both files carry the identical value, so highlighting the second cell
+        // reuses the memoized placeholder extraction of the first.
+        $issue = new Issue(
+            'test.xlf',
+            [
+                'key' => 'shared.key',
+                'files' => [
+                    'en.xlf' => ['value' => 'Hello %name%!', 'placeholders' => ['%name%']],
+                    'de.xlf' => ['value' => 'Hello %name%!', 'placeholders' => ['%name%']],
+                ],
+                'inconsistencies' => ['dummy'],
+            ],
+            'XliffParser',
+            'PlaceholderConsistencyValidator',
+        );
+
+        $output = new BufferedOutput();
+        $validator->renderDetailedOutput($output, [$issue]);
+
+        $this->assertStringContainsString('Hello %name%!', $output->fetch());
+    }
+
     public function testResetState(): void
     {
         $logger = $this->createStub(LoggerInterface::class);

--- a/tests/src/Validator/PlaceholderConsistencyValidatorTest.php
+++ b/tests/src/Validator/PlaceholderConsistencyValidatorTest.php
@@ -388,6 +388,11 @@ final class PlaceholderConsistencyValidatorTest extends TestCase
         $validator->renderDetailedOutput($output, [$issue]);
 
         $this->assertStringContainsString('Hello %name%!', $output->fetch());
+
+        $reflection = new ReflectionClass($validator);
+        $cache = $reflection->getProperty('placeholderCache')->getValue($validator);
+        $this->assertArrayHasKey('Hello %name%!', $cache);
+        $this->assertSame(['%name%'], $cache['Hello %name%!']);
     }
 
     public function testResetState(): void


### PR DESCRIPTION
## Summary

- `extractPlaceholders()` runs five regexes over a translation value, and the same value is processed both during analysis and again while rendering the detail table.
- The extraction result is now cached per value on the validator instance (cleared per run), so repeated extraction of the same value reuses the result.

## Changes

- `src/Validator/PlaceholderConsistencyValidator.php` — memoize `extractPlaceholders()` per value; clear the cache in `resetState()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved placeholder consistency analysis when identical translated values appear across files.
  * Ensured detailed validation output remains accurate for repeated translated content.

* **Tests**
  * Added coverage for reusing placeholder results during detailed output generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->