### PR TITLE
perf: dedupe render keys via hash set instead of in_array

### DIFF
--- a/src/Validator/HtmlTagValidator.php
+++ b/src/Validator/HtmlTagValidator.php
@@ -128,9 +128,7 @@ class HtmlTagValidator extends AbstractValidator implements ValidatorInterface
             $key = $details['key'] ?? 'unknown';
             $files = $details['files'] ?? [];
 
-            if (!in_array($key, $allKeys)) {
-                $allKeys[] = $key;
-            }
+            $allKeys[$key] = true;
 
             foreach ($files as $filePath => $fileInfo) {
                 $fileName = basename((string) $filePath);
@@ -153,7 +151,7 @@ class HtmlTagValidator extends AbstractValidator implements ValidatorInterface
             $header[] = $fileName;
         }
 
-        foreach ($allKeys as $key) {
+        foreach (array_keys($allKeys) as $key) {
             $row = [$key];
             foreach ($fileOrder as $fileName) {
                 $value = $allFilesData[$key][$fileName] ?? '';

--- a/src/Validator/MismatchValidator.php
+++ b/src/Validator/MismatchValidator.php
@@ -144,9 +144,7 @@ class MismatchValidator extends AbstractValidator implements ValidatorInterface
             $files = $details['files'] ?? [];
             $currentFile = basename($issue->getFile());
 
-            if (!in_array($key, $allKeys, true)) {
-                $allKeys[] = $key;
-            }
+            $allKeys[$key] = true;
 
             foreach ($files as $fileInfo) {
                 $fileName = basename($fileInfo['file'] ?? '');
@@ -179,7 +177,7 @@ class MismatchValidator extends AbstractValidator implements ValidatorInterface
             }
         }
 
-        foreach ($allKeys as $key) {
+        foreach (array_keys($allKeys) as $key) {
             $row = [$key];
             foreach ($fileOrder as $fileName) {
                 $value = $allFilesData[$key][$fileName] ?? null;

--- a/src/Validator/PlaceholderConsistencyValidator.php
+++ b/src/Validator/PlaceholderConsistencyValidator.php
@@ -20,7 +20,6 @@ use Symfony\Component\Console\Helper\{Table, TableStyle};
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function count;
-use function in_array;
 
 /**
  * PlaceholderConsistencyValidator.
@@ -117,9 +116,7 @@ class PlaceholderConsistencyValidator extends AbstractValidator implements Valid
             $key = $details['key'] ?? 'unknown';
             $files = $details['files'] ?? [];
 
-            if (!in_array($key, $allKeys)) {
-                $allKeys[] = $key;
-            }
+            $allKeys[$key] = true;
 
             foreach ($files as $filePath => $fileInfo) {
                 $fileName = basename((string) $filePath);
@@ -142,7 +139,7 @@ class PlaceholderConsistencyValidator extends AbstractValidator implements Valid
             $header[] = $fileName;
         }
 
-        foreach ($allKeys as $key) {
+        foreach (array_keys($allKeys) as $key) {
             $row = [$key];
             foreach ($fileOrder as $fileName) {
                 $value = $allFilesData[$key][$fileName] ?? '';


### PR DESCRIPTION
## Summary

- The detailed (verbose) output builders collected unique translation keys with `in_array()` inside a loop over all issues — O(issues²) when many issues are rendered.
- Keys are now deduplicated via an associative array used as a set (`$allKeys[$key] = true`) and iterated with `array_keys()`, preserving first-seen order.

## Changes

- `src/Validator/MismatchValidator.php`, `PlaceholderConsistencyValidator.php`, `HtmlTagValidator.php` — hash-set key deduplication in `renderDetailedOutput()`; drop a now-unused `in_array` import