### PR TITLE
perf: minor render and file-collection optimizations

### DIFF
--- a/src/FileDetector/Collector.php
+++ b/src/FileDetector/Collector.php
@@ -65,10 +65,7 @@ class Collector
                 if ($excludePatterns) {
                     $files = array_filter(
                         $files,
-                        static fn ($file) => !array_filter(
-                            $excludePatterns,
-                            static fn ($pattern) => fnmatch($pattern, basename((string) $file)),
-                        ),
+                        fn ($file) => !$this->matchesAnyPattern(basename((string) $file), $excludePatterns),
                     );
                 }
 
@@ -162,6 +159,23 @@ class Collector
         // @codeCoverageIgnoreEnd
 
         return $files;
+    }
+
+    /**
+     * Returns true as soon as the basename matches any exclude pattern,
+     * short-circuiting instead of evaluating every pattern.
+     *
+     * @param string[] $patterns
+     */
+    private function matchesAnyPattern(string $basename, array $patterns): bool
+    {
+        foreach ($patterns as $pattern) {
+            if (fnmatch($pattern, $basename)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Result/AbstractValidationResultRenderer.php
+++ b/src/Result/AbstractValidationResultRenderer.php
@@ -26,6 +26,13 @@ use function strlen;
  */
 abstract class AbstractValidationResultRenderer implements ValidationResultRendererInterface
 {
+    /**
+     * Resolved current working directory, cached per renderer instance so it is
+     * not recomputed for every path during grouping. `false` means resolution
+     * failed; null means not yet resolved.
+     */
+    private string|false|null $resolvedCwd = null;
+
     public function __construct(
         protected readonly OutputInterface $output,
         protected readonly bool $dryRun = false,
@@ -112,12 +119,8 @@ abstract class AbstractValidationResultRenderer implements ValidationResultRende
 
         $normalizedPath = rtrim($realPath, \DIRECTORY_SEPARATOR);
 
-        $cwd = getcwd();
+        $realCwd = $this->resolvedCwd();
         // @codeCoverageIgnoreStart
-        if (false === $cwd) {
-            return $normalizedPath;
-        }
-        $realCwd = realpath($cwd);
         if (false === $realCwd) {
             return $normalizedPath;
         }
@@ -155,5 +158,19 @@ abstract class AbstractValidationResultRenderer implements ValidationResultRende
     {
         return $validationResult->getOverallResult()
             ->resolveErrorToCommandExitCode($this->dryRun, $this->strict);
+    }
+
+    /**
+     * Resolves and caches the current working directory for this renderer.
+     */
+    private function resolvedCwd(): string|false
+    {
+        if (null !== $this->resolvedCwd) {
+            return $this->resolvedCwd;
+        }
+
+        $cwd = getcwd();
+
+        return $this->resolvedCwd = false === $cwd ? false : realpath($cwd);
     }
 }


### PR DESCRIPTION
## Summary

Two small, safe optimizations from the performance review:

- **Exclude patterns**: the file collector evaluated every exclude pattern for each file. It now short-circuits on the first match.
- **Path normalization**: the result renderer resolved the working directory (`getcwd()` + `realpath()`) for every path while grouping issues. It now resolves it once per renderer instance.

## Changes

- `src/FileDetector/Collector.php` — `matchesAnyPattern()` helper with early return
- `src/Result/AbstractValidationResultRenderer.php` — cache the resolved working directory per instance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file exclusion pattern matching for more consistent filtering.
  * Improved path normalization reliability by caching the resolved working directory during validation result rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->