### PR TITLE
feat: disable KeyNamingConventionValidator by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- feat[!!!]: skip KeyNamingConventionValidator by default (opt-in to reduce false positives)
+
 ## [1.5.0] - 2026-06-29
 
 - feat: add target-language consistency check for XLIFF files (filename locale vs. declared target-language)

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -58,15 +58,18 @@ When the same option is specified in multiple places, this priority applies:
 2. **Configuration file**
 3. **Default values** (lowest priority)
 
-## DuplicateValuesValidator
+## Opt-In Validators
 
 ::: info
-The `DuplicateValuesValidator` is disabled by default to reduce noise in validation results, as duplicate values are often intentional (e.g., common button labels like "OK" or "Cancel").
+The `DuplicateValuesValidator` and the `KeyNamingConventionValidator` are disabled by default to reduce noise in validation results:
+
+- **DuplicateValuesValidator** — duplicate values are often intentional (e.g., common button labels like "OK" or "Cancel").
+- **KeyNamingConventionValidator** — auto-detected naming conventions frequently produce false positives on mixed but intentional key styles.
 :::
 
-To enable it, either:
+To enable one of them, either:
 - Use `--only` to explicitly include it
-- Set `skip: []` in your configuration file
+- Set `skip: []` in your configuration file (enables all validators)
 
 ## Next Steps
 

--- a/docs/reference/validators.md
+++ b/docs/reference/validators.md
@@ -437,9 +437,28 @@ Enforces consistent naming patterns for translation keys.
 
 **Result:** WARNING
 
+::: info Opt-In Validator
+This validator is disabled by default, as auto-detected naming conventions often produce false positives on mixed but intentional key styles. Enable it when you want to enforce a convention.
+:::
+
 ::: tip
 This validator auto-detects the most common pattern in your files. Configure a specific convention for strict enforcement.
 :::
+
+### Enable via CLI
+
+```bash
+composer validate-translations translations/ \
+  --only "MoveElevator\\ComposerTranslationValidator\\Validator\\KeyNamingConventionValidator"
+```
+
+### Enable via Configuration
+
+```yaml
+paths:
+  - translations/
+skip: []  # Empty skip list enables all validators
+```
 
 ### Supported Conventions
 

--- a/src/Command/ValidateTranslationCommand.php
+++ b/src/Command/ValidateTranslationCommand.php
@@ -132,7 +132,7 @@ using multiple validators to ensure consistency, correctness and schema complian
   • <info>EmptyValuesValidator</info>     - Finds empty or whitespace-only translation values
   • <info>EncodingValidator</info>        - Validates file encoding and character issues
   • <info>HtmlTagValidator</info>         - Validates HTML tag consistency across translations
-  • <info>KeyNamingConventionValidator</info> - Validates translation key naming conventions
+  • <info>KeyNamingConventionValidator</info> - Validates translation key naming conventions (opt-in, disabled by default)
   • <info>KeyCountValidator</info>        - Warns when a file exceeds the key count threshold
   • <info>KeyDepthValidator</info>        - Warns when keys exceed the nesting depth threshold
   • <info>PlaceholderConsistencyValidator</info> - Validates placeholder consistency across files

--- a/src/Config/TranslationValidatorConfig.php
+++ b/src/Config/TranslationValidatorConfig.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace MoveElevator\ComposerTranslationValidator\Config;
 
-use MoveElevator\ComposerTranslationValidator\Validator\DuplicateValuesValidator;
+use MoveElevator\ComposerTranslationValidator\Validator\{DuplicateValuesValidator, KeyNamingConventionValidator};
 
 /**
  * TranslationValidatorConfig.
@@ -38,9 +38,15 @@ class TranslationValidatorConfig
     /** @var string[] */
     private array $only = [];
 
-    /** @var string[] */
+    /**
+     * Validators disabled by default (opt-in). They produce too many
+     * intentional/false-positive findings to run unconditionally.
+     *
+     * @var string[]
+     */
     private array $skip = [
         DuplicateValuesValidator::class,
+        KeyNamingConventionValidator::class,
     ];
 
     /** @var string[] */

--- a/tests/src/Config/ConfigFactoryTest.php
+++ b/tests/src/Config/ConfigFactoryTest.php
@@ -73,7 +73,10 @@ final class ConfigFactoryTest extends TestCase
         $this->assertSame([], $config->getFileDetectors());
         $this->assertSame([], $config->getParsers());
         $this->assertSame([], $config->getOnly());
-        $this->assertSame([\MoveElevator\ComposerTranslationValidator\Validator\DuplicateValuesValidator::class], $config->getSkip());
+        $this->assertSame([
+            \MoveElevator\ComposerTranslationValidator\Validator\DuplicateValuesValidator::class,
+            \MoveElevator\ComposerTranslationValidator\Validator\KeyNamingConventionValidator::class,
+        ], $config->getSkip());
         $this->assertSame([], $config->getExclude());
         $this->assertFalse($config->getStrict());
         $this->assertFalse($config->getDryRun());

--- a/tests/src/Config/TranslationValidatorConfigTest.php
+++ b/tests/src/Config/TranslationValidatorConfigTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace MoveElevator\ComposerTranslationValidator\Tests\Config;
 
 use MoveElevator\ComposerTranslationValidator\Config\TranslationValidatorConfig;
-use MoveElevator\ComposerTranslationValidator\Validator\DuplicateValuesValidator;
+use MoveElevator\ComposerTranslationValidator\Validator\{DuplicateValuesValidator, KeyNamingConventionValidator};
 use PHPUnit\Framework\Attributes\{CoversClass, DataProvider};
 use PHPUnit\Framework\TestCase;
 
@@ -84,7 +84,7 @@ final class TranslationValidatorConfigTest extends TestCase
         yield 'addFileDetector' => ['addFileDetector', 'getFileDetectors', 'SomeFileDetector', ['SomeFileDetector']];
         yield 'addParser' => ['addParser', 'getParsers', 'SomeParser', ['SomeParser']];
         yield 'only' => ['only', 'getOnly', 'OnlyValidator', ['OnlyValidator']];
-        yield 'skip' => ['skip', 'getSkip', 'SkipValidator', [DuplicateValuesValidator::class, 'SkipValidator']];
+        yield 'skip' => ['skip', 'getSkip', 'SkipValidator', [DuplicateValuesValidator::class, KeyNamingConventionValidator::class, 'SkipValidator']];
     }
 
     public function testDefaultValues(): void
@@ -94,7 +94,7 @@ final class TranslationValidatorConfigTest extends TestCase
         $this->assertSame([], $this->config->getFileDetectors());
         $this->assertSame([], $this->config->getParsers());
         $this->assertSame([], $this->config->getOnly());
-        $this->assertSame([DuplicateValuesValidator::class], $this->config->getSkip());
+        $this->assertSame([DuplicateValuesValidator::class, KeyNamingConventionValidator::class], $this->config->getSkip());
         $this->assertSame([], $this->config->getExclude());
         $this->assertFalse($this->config->getStrict());
         $this->assertFalse($this->config->getDryRun());
@@ -152,7 +152,7 @@ final class TranslationValidatorConfigTest extends TestCase
             'file-detectors' => [],
             'parsers' => [],
             'only' => [],
-            'skip' => [DuplicateValuesValidator::class],
+            'skip' => [DuplicateValuesValidator::class, KeyNamingConventionValidator::class],
             'exclude' => [],
             'strict' => false,
             'dry-run' => false,


### PR DESCRIPTION
## Summary

Makes `KeyNamingConventionValidator` opt-in (disabled by default), mirroring the existing `DuplicateValuesValidator` behavior. Its auto-detected naming conventions produce too many false positives on mixed-but-intentional key styles to run unconditionally.

Users who want to enforce a naming convention can re-enable it via `--only` or a config with an explicit `skip` (e.g. `skip: []`).

## Changes

- `src/Config/TranslationValidatorConfig.php` — add `KeyNamingConventionValidator` to the default `skip` list
- `src/Command/ValidateTranslationCommand.php` — mark it "(opt-in, disabled by default)" in the help text
- `tests/src/Config/TranslationValidatorConfigTest.php`, `tests/src/Config/ConfigFactoryTest.php` — update the default-skip assertions
- docs (`reference/validators.md`, `configuration/index.md`) — document the opt-in and how to enable it
- `CHANGELOG.md` — note the default change

## Note

This changes default behavior: naming-convention findings no longer appear unless the validator is explicitly enabled. Flagged in the CHANGELOG as a breaking-ish default change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Key naming convention validation is now opt-in and disabled by default to reduce false-positive findings.
  * The validator can be enabled through the command line or configuration settings.

* **Documentation**
  * Updated configuration and validator reference guides with opt-in instructions.
  * Updated command-line help and changelog entries to clarify the default behavior.

* **Tests**
  * Updated configuration tests to reflect the expanded set of validators disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->